### PR TITLE
use the opencloud.namespace to prevent using an empty namespace

### DIFF
--- a/templates/collaboration/deployment.yaml
+++ b/templates/collaboration/deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "opencloud.fullname" . }}-collaboration
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: collaboration

--- a/templates/collaboration/service.yaml
+++ b/templates/collaboration/service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "opencloud.fullname" . }}-collaboration
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: collaboration

--- a/templates/gateway/collaboration-httproute.yaml
+++ b/templates/gateway/collaboration-httproute.yaml
@@ -3,7 +3,7 @@ apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   name: {{ include "opencloud.fullname" . }}-collaboration-httproute
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: collaboration

--- a/templates/gateway/https-httproute.yaml
+++ b/templates/gateway/https-httproute.yaml
@@ -3,7 +3,7 @@ apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   name: {{ include "opencloud.fullname" . }}-httproute
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
 spec:

--- a/templates/gateway/keycloak-https-httproute.yaml
+++ b/templates/gateway/keycloak-https-httproute.yaml
@@ -3,7 +3,7 @@ apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   name: {{ include "opencloud.fullname" . }}-keycloak-http-httproute
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: keycloak

--- a/templates/gateway/minio-httproute.yaml
+++ b/templates/gateway/minio-httproute.yaml
@@ -3,7 +3,7 @@ apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   name: {{ include "opencloud.fullname" . }}-minio-httproute
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: minio

--- a/templates/gateway/onlyoffice-httproute-echo.yaml
+++ b/templates/gateway/onlyoffice-httproute-echo.yaml
@@ -3,7 +3,7 @@ apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   name: {{ include "opencloud.fullname" . }}-onlyoffice-httproute-echo
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: onlyoffice

--- a/templates/gateway/onlyoffice-httproute.yaml
+++ b/templates/gateway/onlyoffice-httproute.yaml
@@ -3,7 +3,7 @@ apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   name: {{ include "opencloud.fullname" . }}-onlyoffice-httproute
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: onlyoffice

--- a/templates/gateway/onlyoffice-tlsroute.yaml
+++ b/templates/gateway/onlyoffice-tlsroute.yaml
@@ -3,7 +3,7 @@ apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: TLSRoute
 metadata:
   name: {{ include "opencloud.fullname" . }}-onlyoffice-tlsroute
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: onlyoffice

--- a/templates/gateway/wopi-https-httproute.yaml
+++ b/templates/gateway/wopi-https-httproute.yaml
@@ -3,7 +3,7 @@ apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   name: {{ include "opencloud.fullname" . }}-wopi-httproute
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: wopi

--- a/templates/gateway/wopi-tlsroute.yaml
+++ b/templates/gateway/wopi-tlsroute.yaml
@@ -4,7 +4,7 @@ apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   name: {{ include "opencloud.fullname" . }}-wopi-tlsroute
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: wopiserver

--- a/templates/keycloak/deployment.yaml
+++ b/templates/keycloak/deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "opencloud.keycloak.fullname" . }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: keycloak

--- a/templates/keycloak/realm-configmap.yaml
+++ b/templates/keycloak/realm-configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "opencloud.keycloak.fullname" . }}-realm
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: keycloak

--- a/templates/keycloak/script-configmap.yaml
+++ b/templates/keycloak/script-configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "opencloud.keycloak.fullname" . }}-script
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: keycloak

--- a/templates/keycloak/service.yaml
+++ b/templates/keycloak/service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "opencloud.keycloak.fullname" . }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: keycloak

--- a/templates/minio/deployment.yaml
+++ b/templates/minio/deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "opencloud.minio.fullname" . }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: minio

--- a/templates/minio/pvc.yaml
+++ b/templates/minio/pvc.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "opencloud.minio.fullname" . }}-data
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "opencloud.namespace" . }}
   annotations:
     "helm.sh/resource-policy": "keep"
   labels:

--- a/templates/minio/service.yaml
+++ b/templates/minio/service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "opencloud.minio.fullname" . }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: minio

--- a/templates/onlyoffice/configmap.yaml
+++ b/templates/onlyoffice/configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "opencloud.fullname" . }}-onlyoffice-config
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: onlyoffice

--- a/templates/onlyoffice/deployment.yaml
+++ b/templates/onlyoffice/deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "opencloud.fullname" . }}-onlyoffice
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: onlyoffice

--- a/templates/onlyoffice/pvc.yaml
+++ b/templates/onlyoffice/pvc.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "opencloud.fullname" . }}-onlyoffice-data
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "opencloud.namespace" . }}
   annotations:
     "helm.sh/resource-policy": "keep"
   labels:

--- a/templates/onlyoffice/service.yaml
+++ b/templates/onlyoffice/service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "opencloud.fullname" . }}-onlyoffice
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: onlyoffice

--- a/templates/opencloud/config-json-configmap.yaml
+++ b/templates/opencloud/config-json-configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "opencloud.opencloud.fullname" . }}-config-json
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: opencloud

--- a/templates/opencloud/configmap.yaml
+++ b/templates/opencloud/configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "opencloud.opencloud.fullname" . }}-config
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: opencloud

--- a/templates/opencloud/deployment.yaml
+++ b/templates/opencloud/deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "opencloud.opencloud.fullname" . }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: opencloud

--- a/templates/opencloud/pvc.yaml
+++ b/templates/opencloud/pvc.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "opencloud.opencloud.fullname" . }}-config
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "opencloud.namespace" . }}
   annotations:
     "helm.sh/resource-policy": "keep"
   labels:
@@ -27,7 +27,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "opencloud.opencloud.fullname" . }}-data
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "opencloud.namespace" . }}
   annotations:
     "helm.sh/resource-policy": "keep"
   labels:

--- a/templates/opencloud/service.yaml
+++ b/templates/opencloud/service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "opencloud.opencloud.fullname" . }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: opencloud

--- a/templates/opencloud/web-extensions-init.yaml
+++ b/templates/opencloud/web-extensions-init.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "opencloud.opencloud.fullname" . }}-web-extensions-init
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: opencloud

--- a/templates/postgres/deployment.yaml
+++ b/templates/postgres/deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "opencloud.postgres.fullname" . }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: postgres

--- a/templates/postgres/pvc.yaml
+++ b/templates/postgres/pvc.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "opencloud.postgres.fullname" . }}-data
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "opencloud.namespace" . }}
   annotations:
     "helm.sh/resource-policy": "keep"
   labels:

--- a/templates/postgres/service.yaml
+++ b/templates/postgres/service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "opencloud.postgres.fullname" . }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: postgres

--- a/templates/tika/deployment.yaml
+++ b/templates/tika/deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "opencloud.fullname" . }}-tika
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: tika

--- a/templates/tika/service.yaml
+++ b/templates/tika/service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "opencloud.fullname" . }}-tika
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: tika


### PR DESCRIPTION
While looking into ingress I ended up with middleware trying use an empty variable. This aligns the existing objects to use the `opencloud.namespace` helper which is good practice.