### PR TITLE
fix(opencloud): remove not used tls configuration

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -43,17 +43,6 @@ global:
     # Domain for Companion
     companion: companion.opencloud.test
 
-  # TLS settings for secure connections
-  tls:
-    # Enable TLS (set to false when using gateway TLS termination externally)
-    enabled: false
-    # Use self-signed certificates. Disable if you don't want to use cert-manager to generate self-signed certs for gateway-api
-    selfSigned: true
-    # ACME email for Let's Encrypt
-    acmeEmail: example@example.org
-    # ACME CA server
-    acmeCAServer: https://acme-v02.api.letsencrypt.org/directory
-
   # Global storage settings
   storage:
     # Storage class for persistent volumes


### PR DESCRIPTION
It is deadcode for me.

There is no `kind: Certificate` and if we need one, you maybe should create it manuelle or enable certmanager (helm `config.enableGatewayAPI=true`) and put on the Gateway the annotation:

```yaml
httpRoute:
  gateway:
    annotations:
      cert-manager.io/cluster-issuer: letsencrypt
```

PS: See #19 