### PR TITLE
Add community governance structure

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,53 @@
+# Contributing to OpenCloud Helm Charts
+
+Thank you for your interest in contributing to the OpenCloud Helm Charts repository!
+
+## Repository Structure
+
+This repository follows a community-driven approach with a simple role model:
+
+- **Contributors**: Anyone who submits PRs
+- **Reviewers**: Experienced contributors who can review and approve PRs
+- **Maintainers**: Active reviewers who can additionally merge PRs and manage releases
+
+You can find the current list of maintainers and reviewers in the [MAINTAINERS.md](./MAINTAINERS.md) file.
+
+## Contribution Workflow
+
+### 1. Fork and Clone
+
+```bash
+git clone https://github.com/YOUR-USERNAME/helm.git
+cd helm
+git remote add upstream https://github.com/opencloud-eu/helm.git
+```
+
+### 2. Create a Branch
+
+```bash
+git checkout -b feature/your-feature-name
+```
+
+### 3. Make Changes and Test
+
+When making changes, please ensure you:
+- Follow Helm best practices
+- Include proper documentation
+- Test your changes with `helm lint` and installation tests
+
+### 4. Submit a Pull Request
+
+- Create a PR from your fork to the main repository
+- Ensure your PR has a clear description of the changes
+- At least one reviewer must approve before a maintainer can merge
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+
+## Becoming a Maintainer or Reviewer
+
+Contributors who make multiple high-quality PRs may be invited to become Reviewers.
+Reviewers who are consistently active and provide valuable reviews may be invited to become Maintainers.
+
+If you're interested in becoming a maintainer or reviewer, please continue contributing and engaging with the project.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,25 @@
+# Maintainers
+
+This file lists the maintainers and reviewers for the OpenCloud Helm Charts repository.
+
+## Maintainers
+
+Maintainers have the ability to merge PRs, create releases, and guide the overall direction of the project.
+
+- @butonic
+
+## Reviewers
+
+Reviewers have the ability to review PRs and approve them, but do not have merge access.
+
+- @michaelstingl
+- @WrenIX
+- @ferenc-hechler
+- @suse-coder
+
+## Becoming a Maintainer or Reviewer
+
+Contributors who make multiple high-quality PRs may be invited to become Reviewers.
+Reviewers who are consistently active and provide valuable reviews may be invited to become Maintainers.
+
+If you're interested in becoming a maintainer or reviewer, please continue contributing and engaging with the project.

--- a/README.md
+++ b/README.md
@@ -47,12 +47,16 @@ For general OpenCloud discussions:
 
 ## 💡 Contributing
 
-We encourage contributions from the community! If you'd like to contribute:
-- Fork this repository
-- Submit a Pull Request
-- Discuss and collaborate on issues
+We encourage contributions from the community! This repository follows a community-driven development model with defined roles and responsibilities.
 
-Please ensure that your PR follows best practices and includes necessary documentation.
+For detailed contribution guidelines, please see our [CONTRIBUTING.md](./CONTRIBUTING.md) document.
+
+This includes:
+- How to submit contributions
+- Our community governance model
+- How to become a reviewer or maintainer
+
+The current maintainers and reviewers are listed in [MAINTAINERS.md](./MAINTAINERS.md).
 
 ## Prerequisites
 


### PR DESCRIPTION
This PR establishes a simple community governance model for the OpenCloud Helm repository as discussed in #33.

## Changes

- **Added CONTRIBUTING.md** with:
  - Description of the repository's community structure
  - Contribution workflow guidance
  - Instructions for becoming a maintainer or reviewer

- **Added MAINTAINERS.md** with:
  - Initial list of maintainers and reviewers
  - Clear roles and responsibilities
  - Path for contributors to become reviewers/maintainers

- **Updated README.md** to:
  - Reference the new governance documents
  - Streamline the Contributing section
  - Keep documentation DRY by pointing to the detailed files

## Why?

This change implements a transparent governance structure that:

1. Clarifies how decisions are made in the repository
2. Creates a path for contributors to take on more responsibility
3. Establishes clear expectations for contributions and reviews
4. Follows open source best practices for community-driven projects

This is just the first step towards building a more active and engaged community around the OpenCloud Helm charts.

Feedback and suggestions for improving the governance model are welcome!