### PR TITLE
Add option to use wildcard hostnames in Gateway API configuration

### DIFF
--- a/charts/opencloud/templates/_helpers/tpl.yaml
+++ b/charts/opencloud/templates/_helpers/tpl.yaml
@@ -160,3 +160,16 @@ Return the appropriate apiVersion for ingress
 {{- print "networking.k8s.io/v1beta1" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Helper function to format hostname for Gateway API resource
+Uses wildcard pattern if enabled in configuration
+*/}}
+{{- define "opencloud.gateway.hostname" -}}
+{{- $domain := .domain -}}
+{{- if $.Values.httpRoute.gateway.useWildcardHostnames -}}
+{{- printf "*.%s" ($domain | regexFind "[^.]+\\.[^.]+$") | quote -}}
+{{- else -}}
+{{- $domain | quote -}}
+{{- end -}}
+{{- end -}}

--- a/charts/opencloud/templates/gateway/gateway.yaml
+++ b/charts/opencloud/templates/gateway/gateway.yaml
@@ -20,7 +20,7 @@ spec:
     - name: opencloud-https
       protocol: HTTPS
       port: {{ .Values.httpRoute.gateway.port | default 443 }}
-      hostname: {{ .Values.global.domain.opencloud | quote }}
+      hostname: {{ include "opencloud.gateway.hostname" (dict "domain" .Values.global.domain.opencloud "Values" .Values) }}
       tls:
         mode: Terminate
         certificateRefs:
@@ -36,7 +36,7 @@ spec:
     - name: keycloak-https
       protocol: HTTPS
       port: {{ .Values.httpRoute.gateway.port | default 443 }}
-      hostname: {{ .Values.global.domain.keycloak | quote }}
+      hostname: {{ include "opencloud.gateway.hostname" (dict "domain" .Values.global.domain.keycloak "Values" .Values) }}
       tls:
         mode: Terminate
         certificateRefs:
@@ -53,7 +53,7 @@ spec:
     - name: minio-https
       protocol: HTTPS
       port: {{ .Values.httpRoute.gateway.port | default 443 }}
-      hostname: {{ .Values.global.domain.minio | quote }}
+      hostname: {{ include "opencloud.gateway.hostname" (dict "domain" .Values.global.domain.minio "Values" .Values) }}
       tls:
         mode: Terminate
         certificateRefs:
@@ -70,7 +70,7 @@ spec:
     - name: onlyoffice-https
       protocol: HTTPS
       port: {{ .Values.httpRoute.gateway.port | default 443 }}
-      hostname: {{ .Values.global.domain.onlyoffice | quote }}
+      hostname: {{ include "opencloud.gateway.hostname" (dict "domain" .Values.global.domain.onlyoffice "Values" .Values) }}
       tls:
         mode: Terminate
         certificateRefs:
@@ -87,7 +87,7 @@ spec:
     - name: collaboration-https
       protocol: HTTPS
       port: {{ .Values.httpRoute.gateway.port | default 443 }}
-      hostname: {{ .Values.global.domain.wopi | quote }}
+      hostname: {{ include "opencloud.gateway.hostname" (dict "domain" .Values.global.domain.wopi "Values" .Values) }}
       tls:
         mode: Terminate
         certificateRefs:

--- a/charts/opencloud/values.yaml
+++ b/charts/opencloud/values.yaml
@@ -521,6 +521,8 @@ httpRoute:
     className: cilium
     # Gateway namespace (defaults to Release.Namespace)
     namespace: ""
+    # Use wildcard hostnames (e.g. *.opencloud.test instead of cloud.opencloud.test)
+    useWildcardHostnames: false
     # Gateway annotations
     annotations:
     # Gateway annotations


### PR DESCRIPTION
## Summary
Add option to use wildcard hostnames in Gateway API configuration

This PR addresses Issue #20 by adding a new configuration option 'useWildcardHostnames' to the Gateway API configuration. When enabled, all hostnames will use wildcard pattern (*.domain.tld) instead of specific subdomains.

## Implementation
- Added a new parameter 'useWildcardHostnames' (default: false) in httpRoute.gateway section
- Created a new Helm template helper 'opencloud.gateway.hostname' to handle hostname formatting
- Updated all Gateway listener configurations to use the new helper

## Test plan
- Deploy chart with 'useWildcardHostnames: false' (default) - hostnames should be as before
- Deploy chart with 'useWildcardHostnames: true' - hostnames should use wildcard pattern (*.domain.tld)

@wrenix Does this solution address your idea in #20? Please let us know if you have any other suggestions.
