### PR TITLE
Improve namespace handling by removing explicit definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ The following sections outline the main configuration parameters for the product
 
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
-| `namespace` | Namespace to install the chart into | `opencloud` |
+| `namespace` | Deprecated: Namespace is now controlled by Helm (.Release.Namespace) | (removed) |
 | `global.domain.opencloud` | Domain for OpenCloud | `cloud.opencloud.test` |
 | `global.domain.keycloak` | Domain for Keycloak | `keycloak.opencloud.test` |
 | `global.domain.minio` | Domain for MinIO | `minio.opencloud.test` |

--- a/charts/opencloud/Chart.yaml
+++ b/charts/opencloud/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
     email: info@opencloud.eu
     url: https://opencloud.eu
 type: application
-version: 0.1.3
+version: 0.1.4
 # renovate: datasource=docker depName=opencloudeu/opencloud-rolling
 appVersion: latest
 kubeVersion: ""

--- a/charts/opencloud/README.md
+++ b/charts/opencloud/README.md
@@ -195,7 +195,7 @@ The following table lists the configurable parameters of the OpenCloud chart and
 
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
-| `namespace` | Namespace to install the chart into | `opencloud` |
+| `namespace` | Deprecated: Namespace is now controlled by Helm (.Release.Namespace) | (removed) |
 | `global.domain.opencloud` | Domain for OpenCloud | `cloud.opencloud.test` |
 | `global.domain.keycloak` | Domain for Keycloak | `keycloak.opencloud.test` |
 | `global.domain.minio` | Domain for MinIO | `minio.opencloud.test` |

--- a/charts/opencloud/templates/NOTES.txt
+++ b/charts/opencloud/templates/NOTES.txt
@@ -57,7 +57,7 @@ The following services have been deployed:
 {{- if .Values.httpRoute.enabled }}
 IMPORTANT: This chart includes HTTPRoute resources that route traffic to the OpenCloud, Keycloak, and MinIO services.
 All HTTPRoutes are configured to use the Gateway named "{{ .Values.httpRoute.gateway.name }}" in the
-{{ if .Values.httpRoute.gateway.namespace }}{{ .Values.httpRoute.gateway.namespace }}{{ else }}{{ .Values.namespace }}{{ end }} namespace.
+{{ if .Values.httpRoute.gateway.namespace }}{{ .Values.httpRoute.gateway.namespace }}{{ else }}{{ include "opencloud.namespace" . }}{{ end }} namespace.
 
 Make sure the Gateway exists and is properly configured to accept traffic for the following domains:
 - OpenCloud: {{ include "opencloud.domain" . }} (Service: {{ include "opencloud.opencloud.fullname" . }}, Port: 9200)

--- a/charts/opencloud/templates/NOTES.txt
+++ b/charts/opencloud/templates/NOTES.txt
@@ -57,7 +57,7 @@ The following services have been deployed:
 {{- if .Values.httpRoute.enabled }}
 IMPORTANT: This chart includes HTTPRoute resources that route traffic to the OpenCloud, Keycloak, and MinIO services.
 All HTTPRoutes are configured to use the Gateway named "{{ .Values.httpRoute.gateway.name }}" in the
-{{ if .Values.httpRoute.gateway.namespace }}{{ .Values.httpRoute.gateway.namespace }}{{ else }}{{ include "opencloud.namespace" . }}{{ end }} namespace.
+{{ .Values.httpRoute.gateway.namespace | default .Release.Namespace }} namespace.
 
 Make sure the Gateway exists and is properly configured to accept traffic for the following domains:
 - OpenCloud: {{ include "opencloud.domain" . }} (Service: {{ include "opencloud.opencloud.fullname" . }}, Port: 9200)

--- a/charts/opencloud/templates/_helpers/tpl.yaml
+++ b/charts/opencloud/templates/_helpers/tpl.yaml
@@ -143,11 +143,7 @@ Create a fully qualified Tika name.
 Return the namespace to use
 */}}
 {{- define "opencloud.namespace" -}}
-{{- if .Values.namespace -}}
-{{- .Values.namespace -}}
-{{- else -}}
 {{- .Release.Namespace -}}
-{{- end -}}
 {{- end }}
 
 {{/*

--- a/charts/opencloud/templates/_helpers/tpl.yaml
+++ b/charts/opencloud/templates/_helpers/tpl.yaml
@@ -139,12 +139,7 @@ Create a fully qualified Tika name.
 {{- printf "%s-tika" (include "opencloud.fullname" .) | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
-{{/*
-Return the namespace to use
-*/}}
-{{- define "opencloud.namespace" -}}
-{{- .Release.Namespace -}}
-{{- end }}
+{{/* namespace helper removed - use .Release.Namespace directly */}}
 
 {{/*
 Return the appropriate apiVersion for ingress

--- a/charts/opencloud/templates/collaboration/deployment.yaml
+++ b/charts/opencloud/templates/collaboration/deployment.yaml
@@ -3,7 +3,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "opencloud.fullname" . }}-collaboration
-  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: collaboration
@@ -55,7 +54,7 @@ spec:
             - name: MICRO_REGISTRY
               value: "nats-js-kv"
             - name: MICRO_REGISTRY_ADDRESS
-              value: "{{ include "opencloud.opencloud.fullname" . }}.{{ include "opencloud.namespace" . }}.svc.cluster.local:9233"
+              value: "{{ include "opencloud.opencloud.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:9233"
             - name: COLLABORATION_WOPI_SRC
               value: "https://{{ include "opencloud.wopi.domain" . }}"
             - name: COLLABORATION_APP_NAME

--- a/charts/opencloud/templates/collaboration/service.yaml
+++ b/charts/opencloud/templates/collaboration/service.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "opencloud.fullname" . }}-collaboration
-  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: collaboration

--- a/charts/opencloud/templates/gateway/collaboration-httproute.yaml
+++ b/charts/opencloud/templates/gateway/collaboration-httproute.yaml
@@ -3,7 +3,6 @@ apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   name: {{ include "opencloud.fullname" . }}-collaboration-httproute
-  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: collaboration

--- a/charts/opencloud/templates/gateway/https-httproute.yaml
+++ b/charts/opencloud/templates/gateway/https-httproute.yaml
@@ -3,7 +3,6 @@ apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   name: {{ include "opencloud.fullname" . }}-httproute
-  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
 spec:

--- a/charts/opencloud/templates/gateway/keycloak-https-httproute.yaml
+++ b/charts/opencloud/templates/gateway/keycloak-https-httproute.yaml
@@ -3,7 +3,6 @@ apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   name: {{ include "opencloud.fullname" . }}-keycloak-http-httproute
-  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: keycloak

--- a/charts/opencloud/templates/gateway/minio-httproute.yaml
+++ b/charts/opencloud/templates/gateway/minio-httproute.yaml
@@ -3,7 +3,6 @@ apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   name: {{ include "opencloud.fullname" . }}-minio-httproute
-  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: minio

--- a/charts/opencloud/templates/gateway/onlyoffice-httproute-echo.yaml
+++ b/charts/opencloud/templates/gateway/onlyoffice-httproute-echo.yaml
@@ -3,7 +3,6 @@ apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   name: {{ include "opencloud.fullname" . }}-onlyoffice-httproute-echo
-  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: onlyoffice

--- a/charts/opencloud/templates/gateway/onlyoffice-httproute.yaml
+++ b/charts/opencloud/templates/gateway/onlyoffice-httproute.yaml
@@ -3,7 +3,6 @@ apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   name: {{ include "opencloud.fullname" . }}-onlyoffice-httproute
-  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: onlyoffice

--- a/charts/opencloud/templates/gateway/onlyoffice-tlsroute.yaml
+++ b/charts/opencloud/templates/gateway/onlyoffice-tlsroute.yaml
@@ -3,7 +3,6 @@ apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: TLSRoute
 metadata:
   name: {{ include "opencloud.fullname" . }}-onlyoffice-tlsroute
-  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: onlyoffice

--- a/charts/opencloud/templates/gateway/reference-grant.yaml
+++ b/charts/opencloud/templates/gateway/reference-grant.yaml
@@ -10,7 +10,7 @@ spec:
   from:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
-      namespace: {{ include "opencloud.namespace" . }}
+      namespace: {{ .Release.Namespace }}
   to:
     - group: gateway.networking.k8s.io
       kind: Gateway
@@ -20,7 +20,6 @@ apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant
 metadata:
   name: {{ include "opencloud.fullname" . }}-cert-reference-grant
-  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
 spec:

--- a/charts/opencloud/templates/gateway/traefik-middleware.yaml
+++ b/charts/opencloud/templates/gateway/traefik-middleware.yaml
@@ -3,7 +3,7 @@ apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: add-x-forwarded-proto-https
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "opencloud.namespace" . }}
 spec:
   headers:
     customRequestHeaders:

--- a/charts/opencloud/templates/gateway/traefik-middleware.yaml
+++ b/charts/opencloud/templates/gateway/traefik-middleware.yaml
@@ -3,7 +3,6 @@ apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: add-x-forwarded-proto-https
-  namespace: {{ include "opencloud.namespace" . }}
 spec:
   headers:
     customRequestHeaders:

--- a/charts/opencloud/templates/gateway/wopi-https-httproute.yaml
+++ b/charts/opencloud/templates/gateway/wopi-https-httproute.yaml
@@ -3,7 +3,6 @@ apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   name: {{ include "opencloud.fullname" . }}-wopi-httproute
-  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: wopi

--- a/charts/opencloud/templates/gateway/wopi-tlsroute.yaml
+++ b/charts/opencloud/templates/gateway/wopi-tlsroute.yaml
@@ -4,7 +4,6 @@ apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   name: {{ include "opencloud.fullname" . }}-wopi-tlsroute
-  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: wopiserver

--- a/charts/opencloud/templates/keycloak/deployment.yaml
+++ b/charts/opencloud/templates/keycloak/deployment.yaml
@@ -3,7 +3,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "opencloud.keycloak.fullname" . }}
-  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: keycloak

--- a/charts/opencloud/templates/keycloak/realm-configmap.yaml
+++ b/charts/opencloud/templates/keycloak/realm-configmap.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "opencloud.keycloak.fullname" . }}-realm
-  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: keycloak

--- a/charts/opencloud/templates/keycloak/script-configmap.yaml
+++ b/charts/opencloud/templates/keycloak/script-configmap.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "opencloud.keycloak.fullname" . }}-script
-  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: keycloak

--- a/charts/opencloud/templates/keycloak/service.yaml
+++ b/charts/opencloud/templates/keycloak/service.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "opencloud.keycloak.fullname" . }}
-  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: keycloak

--- a/charts/opencloud/templates/minio/deployment.yaml
+++ b/charts/opencloud/templates/minio/deployment.yaml
@@ -3,7 +3,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "opencloud.minio.fullname" . }}
-  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: minio

--- a/charts/opencloud/templates/minio/pvc.yaml
+++ b/charts/opencloud/templates/minio/pvc.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "opencloud.minio.fullname" . }}-data
-  namespace: {{ include "opencloud.namespace" . }}
   annotations:
     "helm.sh/resource-policy": "keep"
   labels:

--- a/charts/opencloud/templates/minio/service.yaml
+++ b/charts/opencloud/templates/minio/service.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "opencloud.minio.fullname" . }}
-  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: minio

--- a/charts/opencloud/templates/namespace.yaml
+++ b/charts/opencloud/templates/namespace.yaml
@@ -1,1 +1,0 @@
-{{/* Namespace is created by Helm with --create-namespace flag */}}

--- a/charts/opencloud/templates/onlyoffice/configmap.yaml
+++ b/charts/opencloud/templates/onlyoffice/configmap.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "opencloud.fullname" . }}-onlyoffice-config
-  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: onlyoffice

--- a/charts/opencloud/templates/onlyoffice/deployment.yaml
+++ b/charts/opencloud/templates/onlyoffice/deployment.yaml
@@ -3,7 +3,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "opencloud.fullname" . }}-onlyoffice
-  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: onlyoffice

--- a/charts/opencloud/templates/onlyoffice/pvc.yaml
+++ b/charts/opencloud/templates/onlyoffice/pvc.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "opencloud.fullname" . }}-onlyoffice-data
-  namespace: {{ include "opencloud.namespace" . }}
   annotations:
     "helm.sh/resource-policy": "keep"
   labels:

--- a/charts/opencloud/templates/onlyoffice/service.yaml
+++ b/charts/opencloud/templates/onlyoffice/service.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "opencloud.fullname" . }}-onlyoffice
-  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: onlyoffice

--- a/charts/opencloud/templates/opencloud/config-json-configmap.yaml
+++ b/charts/opencloud/templates/opencloud/config-json-configmap.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "opencloud.opencloud.fullname" . }}-config-json
-  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: opencloud

--- a/charts/opencloud/templates/opencloud/configmap.yaml
+++ b/charts/opencloud/templates/opencloud/configmap.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "opencloud.opencloud.fullname" . }}-config
-  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: opencloud

--- a/charts/opencloud/templates/opencloud/deployment.yaml
+++ b/charts/opencloud/templates/opencloud/deployment.yaml
@@ -3,7 +3,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "opencloud.opencloud.fullname" . }}
-  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: opencloud

--- a/charts/opencloud/templates/opencloud/pvc.yaml
+++ b/charts/opencloud/templates/opencloud/pvc.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "opencloud.opencloud.fullname" . }}-config
-  namespace: {{ include "opencloud.namespace" . }}
   annotations:
     "helm.sh/resource-policy": "keep"
   labels:
@@ -27,7 +26,6 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "opencloud.opencloud.fullname" . }}-data
-  namespace: {{ include "opencloud.namespace" . }}
   annotations:
     "helm.sh/resource-policy": "keep"
   labels:

--- a/charts/opencloud/templates/opencloud/service.yaml
+++ b/charts/opencloud/templates/opencloud/service.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "opencloud.opencloud.fullname" . }}
-  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: opencloud

--- a/charts/opencloud/templates/opencloud/web-extensions-init.yaml
+++ b/charts/opencloud/templates/opencloud/web-extensions-init.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "opencloud.opencloud.fullname" . }}-web-extensions-init
-  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: opencloud

--- a/charts/opencloud/templates/postgres/deployment.yaml
+++ b/charts/opencloud/templates/postgres/deployment.yaml
@@ -3,7 +3,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "opencloud.postgres.fullname" . }}
-  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: postgres

--- a/charts/opencloud/templates/postgres/pvc.yaml
+++ b/charts/opencloud/templates/postgres/pvc.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "opencloud.postgres.fullname" . }}-data
-  namespace: {{ include "opencloud.namespace" . }}
   annotations:
     "helm.sh/resource-policy": "keep"
   labels:

--- a/charts/opencloud/templates/postgres/service.yaml
+++ b/charts/opencloud/templates/postgres/service.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "opencloud.postgres.fullname" . }}
-  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: postgres

--- a/charts/opencloud/templates/tika/deployment.yaml
+++ b/charts/opencloud/templates/tika/deployment.yaml
@@ -3,7 +3,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "opencloud.fullname" . }}-tika
-  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: tika

--- a/charts/opencloud/templates/tika/service.yaml
+++ b/charts/opencloud/templates/tika/service.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "opencloud.fullname" . }}-tika
-  namespace: {{ include "opencloud.namespace" . }}
   labels:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: tika

--- a/charts/opencloud/values.yaml
+++ b/charts/opencloud/values.yaml
@@ -21,9 +21,6 @@
 # GLOBAL SETTINGS
 # =====================================================================
 
-# Create the namespace if it doesn't exist
-createNamespace: true
-
 # Global settings that apply across components
 global:
   # Domain settings for various services

--- a/charts/opencloud/values.yaml
+++ b/charts/opencloud/values.yaml
@@ -21,8 +21,6 @@
 # GLOBAL SETTINGS
 # =====================================================================
 
-# Deprecated: Namespace is now controlled by Helm (.Release.Namespace)
-# namespace: ""
 # Create the namespace if it doesn't exist
 createNamespace: true
 

--- a/charts/opencloud/values.yaml
+++ b/charts/opencloud/values.yaml
@@ -21,8 +21,8 @@
 # GLOBAL SETTINGS
 # =====================================================================
 
-# Namespace to install the chart into
-namespace: ""
+# Deprecated: Namespace is now controlled by Helm (.Release.Namespace)
+# namespace: ""
 # Create the namespace if it doesn't exist
 createNamespace: true
 


### PR DESCRIPTION
## Summary

This PR fixes issue #10 by replacing the use of `.Values.namespace` with `.Release.Namespace` in the Helm chart. This follows Helm best practices by using the current release namespace rather than requiring a namespace to be explicitly specified in values.yaml.

## Changes
- Update `opencloud.namespace` helper function to use only `.Release.Namespace`
- Update references in traefik-middleware.yaml to use the helper function
- Update NOTES.txt to use the helper function
- Mark the namespace field in values.yaml as deprecated
- Update README.md files to reflect the namespace deprecation

## Related Issues
Fixes opencloud-eu/helm#10