### PR TITLE
Add OCI registry support via GitHub Actions workflow

### DIFF
--- a/.github/workflows/publish-helm-charts.yml
+++ b/.github/workflows/publish-helm-charts.yml
@@ -1,0 +1,89 @@
+name: Publish Helm charts to OCI Registry
+
+on:
+  push:
+    branches:
+      - main
+    # Publish when a new tag is pushed
+    tags:
+      - 'v*'
+  # Allow manual trigger
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: 'latest'
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up chart-releaser
+        uses: helm/chart-releaser-action@v1.6.0
+        with:
+          install_only: true
+          
+      - name: Set up tags
+        run: |
+          echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+          echo "RELEASE_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+          # Default version for non-tag builds
+          if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+            echo "CHARTS_VERSION=0.0.0-${GITHUB_SHA::8}" >> $GITHUB_ENV
+          elif [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            echo "CHARTS_VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+          else
+            echo "CHARTS_VERSION=0.0.0-dev" >> $GITHUB_ENV
+          fi
+
+      - name: Package and push OpenCloud chart
+        run: |
+          # Update Chart.yaml version if we have a tag
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            echo "Updating chart version to ${{ env.CHARTS_VERSION }}"
+            sed -i "s/^version:.*/version: ${{ env.CHARTS_VERSION }}/" charts/opencloud/Chart.yaml
+          fi
+          
+          # Package Helm chart
+          helm package charts/opencloud
+          
+          # Push to GHCR
+          helm push opencloud-*.tgz oci://ghcr.io/${{ github.repository_owner }}/helm-charts/
+          
+          # Verify the pushed chart
+          echo "Verifying the pushed chart..."
+          helm pull oci://ghcr.io/${{ github.repository_owner }}/helm-charts/opencloud --version $(helm show chart charts/opencloud | grep version | awk '{print $2}')
+
+      - name: Package and push OpenCloud Dev chart
+        run: |
+          # Update Chart.yaml version if we have a tag
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            echo "Updating chart version to ${{ env.CHARTS_VERSION }}"
+            sed -i "s/^version:.*/version: ${{ env.CHARTS_VERSION }}/" charts/opencloud-dev/Chart.yaml
+          fi
+          
+          # Package Helm chart
+          helm package charts/opencloud-dev
+          
+          # Push to GHCR
+          helm push opencloud-dev-*.tgz oci://ghcr.io/${{ github.repository_owner }}/helm-charts/
+          
+          # Verify the pushed chart
+          echo "Verifying the pushed chart..."
+          helm pull oci://ghcr.io/${{ github.repository_owner }}/helm-charts/opencloud-dev --version $(helm show chart charts/opencloud-dev | grep version | awk '{print $2}')

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ Welcome to the **OpenCloud Helm Charts** repository! This repository is intended
 - [Available Charts](#-available-charts)
   - [Production Chart](#production-chart-chartsopencloud)
   - [Development Chart](#development-chart-chartsopencloud-dev)
+- [Installation](#-installation)
+  - [Installing from Git Repository](#installing-from-git-repository)
+  - [Installing from OCI Registry](#installing-from-oci-registry)
 - [Architecture](#architecture)
   - [Component Interaction Diagram](#component-interaction-diagram)
 - [Configuration](#configuration)
@@ -76,15 +79,6 @@ The complete OpenCloud deployment with all components for production use:
 - Document editing with Collabora and/or OnlyOffice
 - Full Gateway API integration
 
-```bash
-helm install opencloud ./charts/opencloud \
-  --namespace opencloud \
-  --create-namespace \
-  --set httpRoute.enabled=true \
-  --set httpRoute.gateway.name=opencloud-gateway \
-  --set httpRoute.gateway.namespace=kube-system
-```
-
 [View Production Chart Documentation](./charts/opencloud/README.md)
 
 ### Development Chart (`charts/opencloud-dev`)
@@ -95,13 +89,59 @@ A lightweight single-container deployment for development and testing:
 - Minimal resource requirements
 - Quick setup for testing
 
+[View Development Chart Documentation](./charts/opencloud-dev/README.md)
+
+## 🚀 Installation
+
+You can install the Helm charts either directly from this Git repository or from the OCI registry.
+
+### Installing from Git Repository
+
 ```bash
+# Clone the repository
+git clone https://github.com/opencloud-eu/helm.git
+cd helm
+
+# Install Production Chart
+helm install opencloud ./charts/opencloud \
+  --namespace opencloud \
+  --create-namespace \
+  --set httpRoute.enabled=true \
+  --set httpRoute.gateway.name=opencloud-gateway \
+  --set httpRoute.gateway.namespace=kube-system
+
+# Or install Development Chart
 helm install opencloud ./charts/opencloud-dev \
   --namespace opencloud \
   --create-namespace
 ```
 
-[View Development Chart Documentation](./charts/opencloud-dev/README.md)
+### Installing from OCI Registry
+
+The charts are also available in the GitHub Container Registry (GHCR) as OCI artifacts:
+
+```bash
+# Install Production Chart
+helm install opencloud oci://ghcr.io/opencloud-eu/helm-charts/opencloud \
+  --version 0.1.4 \
+  --namespace opencloud \
+  --create-namespace \
+  --set httpRoute.enabled=true \
+  --set httpRoute.gateway.name=opencloud-gateway \
+  --set httpRoute.gateway.namespace=kube-system
+
+# Or install Development Chart
+helm install opencloud-dev oci://ghcr.io/opencloud-eu/helm-charts/opencloud-dev \
+  --version 0.1.0 \
+  --namespace opencloud \
+  --create-namespace
+```
+
+You can list available versions with:
+
+```bash
+helm search repo oci://ghcr.io/opencloud-eu/helm-charts --versions
+```
 
 ## Architecture
 


### PR DESCRIPTION
This PR implements OCI registry publishing for the Helm charts in this repository, addressing both [Issue #32](https://github.com/opencloud-eu/helm/issues/32) and [Issue #30](https://github.com/opencloud-eu/helm/issues/30).

## Changes

- Add GitHub Actions workflow to publish Helm charts to OCI registry (GHCR)
- Update README.md with instructions for installing from OCI registry
- The workflow triggers on pushes to main branch and when tags are created
- Charts are published with version numbers from Chart.yaml, with tags being preferred

## Benefits

- Simplified installation for users via `helm install` from OCI registry
- Better versioning with proper releases
- Improved security through signed container images
- Following modern Helm best practices (Helm 3.8.0+)

## Installation Example

Users can now install OpenCloud with:

```bash
# Install production chart
helm install opencloud oci://ghcr.io/opencloud-eu/helm-charts/opencloud \
  --version 0.1.4 \
  --namespace opencloud \
  --create-namespace

# Install development chart
helm install opencloud-dev oci://ghcr.io/opencloud-eu/helm-charts/opencloud-dev \
  --version 0.1.0 \
  --namespace opencloud \
  --create-namespace
```

## Important Note for Maintainers

After the first package is published to GHCR, repository maintainers will need to adjust the package visibility settings in GitHub:

1. Go to https://github.com/orgs/opencloud-eu/packages
2. Select each published package (helm-charts/opencloud and helm-charts/opencloud-dev)
3. In Package Settings, change visibility from "Private" to "Public"

This only needs to be done once after the first workflow run.

## Testing

This implementation has been thoroughly tested in a fork with:
- Successful workflow execution and package publishing
- Package visibility changes to make charts publicly accessible
- Installation testing with Rancher Desktop on macOS