### PR TITLE
Fix service name inconsistency by using dynamic Release.Name

### DIFF
--- a/charts/opencloud-dev/templates/opencloud-service.yaml
+++ b/charts/opencloud-dev/templates/opencloud-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: opencloud-service
+  name: {{ .Release.Name }}-service
   labels:
     app: opencloud
 spec:


### PR DESCRIPTION
This PR fixes the issue reported in #42 where there's an inconsistency between the service name in the templates and the name referenced in NOTES.txt.

### Changes
- Updated the service definition in `opencloud-service.yaml` to use `{{ .Release.Name }}-service` instead of the hardcoded `opencloud-service`
- This ensures that the service name dynamically matches what's referenced in NOTES.txt
- Makes the chart more flexible by having all resource names consistently use the release name

### Testing
- Verified that the service is now created with the proper name that matches instructions in NOTES.txt
- The port-forwarding command in NOTES.txt now works correctly with the actual service name

This change aligns with Helm best practices by using dynamic resource naming based on the release name, making the chart more maintainable and consistent.

Closes #42