### PR TITLE
fix volumeMount defined twice in opencloud-collaboration

### DIFF
--- a/charts/opencloud/templates/collaboration/deployment.yaml
+++ b/charts/opencloud/templates/collaboration/deployment.yaml
@@ -95,9 +95,6 @@ spec:
             initialDelaySeconds: 200
             periodSeconds: 5
             failureThreshold: 1
-          volumeMounts:
-            - name: etc-opencloud
-              mountPath: /etc/opencloud
           resources:
             {{- toYaml .Values.onlyoffice.collaboration.resources | nindent 12 }}
       volumes:


### PR DESCRIPTION
Hello, the volumeMounts is defined twice in this file.  ( line 85 too ) 
When deploying with fluxcd it failed. 