### PR TITLE
charts/opencloud/values.yaml: do not set the cert-manager annotation by default

### DIFF
--- a/charts/opencloud/values.yaml
+++ b/charts/opencloud/values.yaml
@@ -585,5 +585,6 @@ ingress:
 
   # Custom annotations applied to all ingress resources.
   # These are merged with any annotations from 'annotationsPreset' (if set).
-  annotations:
-    cert-manager.io/cluster-issuer: letsencrypt
+  annotations: {}
+    # Example:
+    # cert-manager.io/cluster-issuer: letsencrypt


### PR DESCRIPTION
Do not set the cert-manager annotation on the ingress, only show it as an example.

As a user, it is not possible to remove this annotation easily, if I need to set other annotations, too. Hence, only use it as an example but do not set it by default.