### PR TITLE
fix: Change Gateway name from cilium-gateway to opencloud-gateway

### DIFF
--- a/charts/opencloud/README.md
+++ b/charts/opencloud/README.md
@@ -491,7 +491,7 @@ Create a Gateway resource to expose your services:
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
-  name: cilium-gateway
+  name: opencloud-gateway
   namespace: kube-system
 spec:
   gatewayClassName: cilium


### PR DESCRIPTION
## Description

This PR fixes the Gateway name mismatch in the documentation that was reported in #72.

## Problem

The Gateway API setup guide had inconsistent Gateway names:
- **Step 4**: Created a Gateway named `cilium-gateway`
- **Step 6**: Referenced `--set httpRoute.gateway.name=opencloud-gateway`

This caused HTTPRoutes to fail because they were looking for a Gateway that doesn't exist.

## Root Cause

This inconsistency was introduced after PR #16, which made Gateway API support generic and changed the expected gateway name from `cilium-gateway` to `opencloud-gateway`. However, the documentation in Step 4 wasn't updated to reflect this change.

## Solution

Changed the Gateway name in Step 4 from `cilium-gateway` to `opencloud-gateway` to match what the Helm chart expects.

Note: `gatewayClassName: cilium` remains unchanged as it refers to the Gateway controller implementation, not the instance name.

Fixes #72