### PR TITLE
[opencloud] remove default for port 443, as that is set in the values.yaml as default already

### DIFF
--- a/charts/opencloud/templates/gateway/gateway.yaml
+++ b/charts/opencloud/templates/gateway/gateway.yaml
@@ -19,7 +19,7 @@ spec:
   listeners:
     - name: opencloud-https
       protocol: HTTPS
-      port: {{ .Values.httpRoute.gateway.port | default 443 }}
+      port: {{ .Values.httpRoute.gateway.port }}
       hostname: {{ .Values.global.domain.opencloud | quote }}
       tls:
         mode: Terminate
@@ -35,7 +35,7 @@ spec:
     {{- if .Values.keycloak.enabled }}
     - name: keycloak-https
       protocol: HTTPS
-      port: {{ .Values.httpRoute.gateway.port | default 443 }}
+      port: {{ .Values.httpRoute.gateway.port }}
       hostname: {{ .Values.global.domain.keycloak | quote }}
       tls:
         mode: Terminate
@@ -52,7 +52,7 @@ spec:
     {{- if and .Values.opencloud.storage.s3.internal.enabled .Values.opencloud.storage.s3.internal.httpRoute.enabled }}
     - name: minio-https
       protocol: HTTPS
-      port: {{ .Values.httpRoute.gateway.port | default 443 }}
+      port: {{ .Values.httpRoute.gateway.port }}
       hostname: {{ .Values.global.domain.minio | quote }}
       tls:
         mode: Terminate
@@ -69,7 +69,7 @@ spec:
     {{- if .Values.collabora.enabled }}
     - name: collabora-https
       protocol: HTTPS
-      port: {{ .Values.httpRoute.gateway.port | default 443 }}
+      port: {{ .Values.httpRoute.gateway.port }}
       hostname: {{ .Values.global.domain.collabora | quote }}
       tls:
         mode: Terminate
@@ -86,7 +86,7 @@ spec:
     {{- if .Values.onlyoffice.enabled }}
     - name: onlyoffice-https
       protocol: HTTPS
-      port: {{ .Values.httpRoute.gateway.port | default 443 }}
+      port: {{ .Values.httpRoute.gateway.port }}
       hostname: {{ .Values.global.domain.onlyoffice | quote }}
       tls:
         mode: Terminate
@@ -103,7 +103,7 @@ spec:
     {{- if and .Values.onlyoffice.collaboration.enabled .Values.onlyoffice.enabled }}
     - name: collaboration-https
       protocol: HTTPS
-      port: {{ .Values.httpRoute.gateway.port | default 443 }}
+      port: {{ .Values.httpRoute.gateway.port }}
       hostname: {{ .Values.global.domain.wopi | quote }}
       tls:
         mode: Terminate


### PR DESCRIPTION
Partial fix for #78 (removes the useless `default 443` for for the httpRoute.gateway.port