### PR TITLE
use global.tls.enabled for gatewayAPI resources

### DIFF
--- a/charts/opencloud/templates/gateway/gateway.yaml
+++ b/charts/opencloud/templates/gateway/gateway.yaml
@@ -17,8 +17,16 @@ spec:
       {{- toYaml . | nindent 4 }}
   {{- end }}
   listeners:
+    {{- if .Values.global.tls.enabled }}
     - name: opencloud-https
+    {{- else }}
+    - name: opencloud-http
+    {{- end }}
+      {{- if .Values.global.tls.enabled }}
       protocol: HTTPS
+      {{- else }}
+      protocol: HTTP
+      {{- end }}
       port: {{ .Values.httpRoute.gateway.port | default 443 }}
       hostname: {{ .Values.global.domain.opencloud | quote }}
       {{- if .Values.global.tls.enabled }}

--- a/charts/opencloud/templates/gateway/gateway.yaml
+++ b/charts/opencloud/templates/gateway/gateway.yaml
@@ -43,8 +43,16 @@ spec:
             matchLabels:
               kubernetes.io/metadata.name: {{ .Values.httpRoute.gateway.namespace | default .Release.Namespace }}
     {{- if .Values.keycloak.enabled }}
+    {{- if .Values.global.tls.enabled }}
     - name: keycloak-https
+    {{- else }}
+    - name: keycloak-http
+    {{- end }}
+      {{- if .Values.global.tls.enabled }}
       protocol: HTTPS
+      {{- else }}
+      protocol: HTTP
+      {{- end }}
       port: {{ .Values.httpRoute.gateway.port | default 443 }}
       hostname: {{ .Values.global.domain.keycloak | quote }}
       {{- if .Values.global.tls.enabled }}

--- a/charts/opencloud/templates/gateway/gateway.yaml
+++ b/charts/opencloud/templates/gateway/gateway.yaml
@@ -21,11 +21,13 @@ spec:
       protocol: HTTPS
       port: {{ .Values.httpRoute.gateway.port | default 443 }}
       hostname: {{ .Values.global.domain.opencloud | quote }}
+      {{- if .Values.global.tls.enabled }}
       tls:
         mode: Terminate
         certificateRefs:
           - name: opencloud-wildcard-tls
             namespace: {{ .Values.httpRoute.gateway.namespace | default .Release.Namespace }}
+      {{- end }}
       allowedRoutes:
         namespaces:
           from: Selector
@@ -37,11 +39,13 @@ spec:
       protocol: HTTPS
       port: {{ .Values.httpRoute.gateway.port | default 443 }}
       hostname: {{ .Values.global.domain.keycloak | quote }}
+      {{- if .Values.global.tls.enabled }}
       tls:
         mode: Terminate
         certificateRefs:
           - name: opencloud-wildcard-tls
             namespace: {{ .Values.httpRoute.gateway.namespace | default .Release.Namespace }}
+      {{- end }}
       allowedRoutes:
         namespaces:
           from: Selector
@@ -54,11 +58,13 @@ spec:
       protocol: HTTPS
       port: {{ .Values.httpRoute.gateway.port | default 443 }}
       hostname: {{ .Values.global.domain.minio | quote }}
+      {{- if .Values.global.tls.enabled }}
       tls:
         mode: Terminate
         certificateRefs:
           - name: opencloud-wildcard-tls
             namespace: {{ .Values.httpRoute.gateway.namespace | default .Release.Namespace }}
+      {{- end }}
       allowedRoutes:
         namespaces:
           from: Selector
@@ -71,11 +77,13 @@ spec:
       protocol: HTTPS
       port: {{ .Values.httpRoute.gateway.port | default 443 }}
       hostname: {{ .Values.global.domain.collabora | quote }}
+      {{- if .Values.global.tls.enabled }}
       tls:
         mode: Terminate
         certificateRefs:
           - name: opencloud-wildcard-tls
             namespace: {{ .Values.httpRoute.gateway.namespace | default .Release.Namespace }}
+      {{- end }}
       allowedRoutes:
         namespaces:
           from: Selector
@@ -88,11 +96,13 @@ spec:
       protocol: HTTPS
       port: {{ .Values.httpRoute.gateway.port | default 443 }}
       hostname: {{ .Values.global.domain.onlyoffice | quote }}
+      {{- if .Values.global.tls.enabled }}
       tls:
         mode: Terminate
         certificateRefs:
           - name: opencloud-wildcard-tls
             namespace: {{ .Values.httpRoute.gateway.namespace | default .Release.Namespace }}
+      {{- end }}
       allowedRoutes:
         namespaces:
           from: Selector
@@ -105,11 +115,13 @@ spec:
       protocol: HTTPS
       port: {{ .Values.httpRoute.gateway.port | default 443 }}
       hostname: {{ .Values.global.domain.wopi | quote }}
+      {{- if .Values.global.tls.enabled }}
       tls:
         mode: Terminate
         certificateRefs:
           - name: opencloud-wildcard-tls
             namespace: {{ .Values.httpRoute.gateway.namespace | default .Release.Namespace }}
+      {{- end }}
       allowedRoutes:
         namespaces:
           from: Selector

--- a/charts/opencloud/templates/gateway/gateway.yaml
+++ b/charts/opencloud/templates/gateway/gateway.yaml
@@ -151,8 +151,16 @@ spec:
               kubernetes.io/metadata.name: {{ .Values.httpRoute.gateway.namespace | default .Release.Namespace }}
     {{- end }}
     {{- if and .Values.onlyoffice.collaboration.enabled .Values.onlyoffice.enabled }}
+    {{- if .Values.global.tls.enabled }}
     - name: collaboration-https
+    {{- else }}
+    - name: collaboration-http
+    {{- end }}
+      {{- if .Values.global.tls.enabled }}
       protocol: HTTPS
+      {{- else }}
+      protocol: HTTP
+      {{- end }}
       port: {{ .Values.httpRoute.gateway.port | default 443 }}
       hostname: {{ .Values.global.domain.wopi | quote }}
       {{- if .Values.global.tls.enabled }}

--- a/charts/opencloud/templates/gateway/gateway.yaml
+++ b/charts/opencloud/templates/gateway/gateway.yaml
@@ -97,8 +97,16 @@ spec:
               kubernetes.io/metadata.name: {{ .Values.httpRoute.gateway.namespace | default .Release.Namespace }}
     {{- end }}
     {{- if .Values.collabora.enabled }}
+    {{- if .Values.global.tls.enabled }}
     - name: collabora-https
+    {{- else }}
+    - name: collabora-http
+    {{- end }}
+      {{- if .Values.global.tls.enabled }}
       protocol: HTTPS
+      {{- else }}
+      protocol: HTTP
+      {{- end }}
       port: {{ .Values.httpRoute.gateway.port | default 443 }}
       hostname: {{ .Values.global.domain.collabora | quote }}
       {{- if .Values.global.tls.enabled }}

--- a/charts/opencloud/templates/gateway/gateway.yaml
+++ b/charts/opencloud/templates/gateway/gateway.yaml
@@ -70,8 +70,16 @@ spec:
               kubernetes.io/metadata.name: {{ .Values.httpRoute.gateway.namespace | default .Release.Namespace }}
     {{- end }}
     {{- if and .Values.opencloud.storage.s3.internal.enabled .Values.opencloud.storage.s3.internal.httpRoute.enabled }}
+    {{- if .Values.global.tls.enabled }}
     - name: minio-https
+    {{- else }}
+    - name: minio-http
+    {{- end }}
+      {{- if .Values.global.tls.enabled }}
       protocol: HTTPS
+      {{- else }}
+      protocol: HTTP
+      {{- end }}
       port: {{ .Values.httpRoute.gateway.port | default 443 }}
       hostname: {{ .Values.global.domain.minio | quote }}
       {{- if .Values.global.tls.enabled }}

--- a/charts/opencloud/templates/gateway/gateway.yaml
+++ b/charts/opencloud/templates/gateway/gateway.yaml
@@ -124,8 +124,16 @@ spec:
               kubernetes.io/metadata.name: {{ .Values.httpRoute.gateway.namespace | default .Release.Namespace }}
     {{- end }}
     {{- if .Values.onlyoffice.enabled }}
+    {{- if .Values.global.tls.enabled }}
     - name: onlyoffice-https
+    {{- else }}
+    - name: onlyoffice-http
+    {{- end }}
+      {{- if .Values.global.tls.enabled }}
       protocol: HTTPS
+      {{- else }}
+      protocol: HTTP
+      {{- end }}
       port: {{ .Values.httpRoute.gateway.port | default 443 }}
       hostname: {{ .Values.global.domain.onlyoffice | quote }}
       {{- if .Values.global.tls.enabled }}


### PR DESCRIPTION
fix #60 

## Notes

This is ugly. Having the protocol in the name means it needs another if-condition.

I tried using inline if-conditions, but they do not make this chart more readable.

I thought about using YAML anchors or similar, but those would make this more complex.