### PR TITLE
Add kastl-ars and Tim-herbie as reviewers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -16,6 +16,8 @@ Reviewers have the ability to review PRs and approve them, but do not have merge
 - @WrenIX
 - @ferenc-hechler
 - @suse-coder
+- @kastl-ars
+- @Tim-herbie
 
 ## Becoming a Maintainer or Reviewer
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -16,7 +16,7 @@ Reviewers have the ability to review PRs and approve them, but do not have merge
 - @WrenIX
 - @ferenc-hechler
 - @suse-coder
-- @kastl-ars
+- @johanneskastl / @kastl-ars
 - @Tim-herbie
 
 ## Becoming a Maintainer or Reviewer


### PR DESCRIPTION
## Summary

This PR proposes adding two active contributors as official reviewers to recognize their valuable contributions and enable them to help with the review process.

## Analysis Method

This assessment was conducted with AI assistance to ensure a comprehensive and objective review of contributions across all PRs, issues, and interactions. 🤖

## Nominees

### @kastl-ars
- **10 high-quality PRs** submitted (May 29 - June 3, 2025)
- Demonstrated expertise in:
  - Gateway API configuration
  - Helm chart best practices
  - Documentation improvements
  - Code consistency and cleanup
- 7 PRs ready to merge, showing attention to quality
- Systematically improved chart consistency

### @Tim-herbie  
- **Valuable issue reports** (#51, #53) identifying important architectural concerns
- **PR #63**: Comprehensive security improvement adding secrets support
- Demonstrated expertise in:
  - Security/secrets handling
  - Multi-replica/HA deployments
  - Practical deployment challenges
- Responsive to feedback and collaborative

## Rationale

Both contributors have demonstrated:
- Deep understanding of Helm charts
- Commitment to improving the project
- Quality contributions that follow best practices
- Good communication and collaboration skills

Adding them as reviewers will:
- Distribute review workload
- Bring fresh perspectives
- Recognize their contributions
- Strengthen the community

Per CONTRIBUTING.md: "Contributors who make multiple high-quality PRs may be invited to become Reviewers."

Both nominees clearly meet this criterion.

## Review Process

@WrenIX @ferenc-hechler @suse-coder - Please approve this PR to add these two active contributors as reviewers.

@butonic - After reviewer approvals, please merge and set repository permissions for the new reviewers.