### PR TITLE
feat: implement external Keycloak support (fixes #75, #82)

### DIFF
--- a/charts/opencloud/Chart.yaml
+++ b/charts/opencloud/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
     email: info@opencloud.eu
     url: https://opencloud.eu
 type: application
-version: 0.1.7
+version: 0.2.0
 # renovate: datasource=docker depName=opencloudeu/opencloud-rolling
 appVersion: latest
 kubeVersion: ""

--- a/charts/opencloud/README.md
+++ b/charts/opencloud/README.md
@@ -224,6 +224,8 @@ This will prepend `my-registry.com/` to all image references in the chart. For e
 | `global.domain.wopi` | Domain for WOPI server | `wopiserver.opencloud.test` |
 | `global.tls.enabled` | Enable TLS (set to false when using gateway TLS termination externally) | `false` |
 | `global.tls.secretName` | secretName for TLS certificate | `""` |
+| `global.oidc.issuer` | OpenID Connect Issuer URL | `""` generated to use the internal keycloak|
+| `global.oidc.clientId` | OpenID Connect Client ID used by OpenCloud | `"web"` |
 | `global.storage.storageClass` | Storage class for persistent volumes | `""` |
 | `global.image.registry` | Global registry override for all images (e.g., `my-registry.com`) | `""` |
 | `global.image.pullPolicy` | Global pull policy override for all images (`Always`, `IfNotPresent`, `Never`) | `""` |
@@ -275,7 +277,7 @@ This will prepend `my-registry.com/` to all image references in the chart. For e
 
 ### Keycloak Settings
 
-Keycloak configuration follows the standardized internal/external pattern (see issue #64).
+By default the chart deploys an internal keycloak. It can be disabled and replaced with an external IdP.
 
 #### Internal Keycloak
 
@@ -295,29 +297,20 @@ Keycloak configuration follows the standardized internal/external pattern (see i
 
 > **Note**: When using internal Keycloak with multiple OpenCloud replicas (`opencloud.replicas > 1`), you must use an external shared database or LDAP. The embedded IDM does not support replication. See [issue #53](https://github.com/opencloud-eu/helm/issues/53) for details.
 
-#### External Keycloak
-
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `keycloak.external.enabled` | Enable external Keycloak | `false` |
-| `keycloak.external.url` | External Keycloak URL (without /realms/...) | `""` |
-| `keycloak.external.realm` | External Keycloak realm | `openCloud` |
-| `keycloak.external.clientId` | External Keycloak client ID | `web` |
-
-#### Example: Using External Keycloak
+#### Example: Using External IDP
 
 ```yaml
+global:
+  oidc:
+    issuer: "https://idp.example.com/realms/openCloud"
+    clientId: "opencloud-web"
+
 keycloak:
   internal:
     enabled: false
-  external:
-    enabled: true
-    url: "https://keycloak.example.com"
-    realm: "my-realm"
-    clientId: "opencloud-web"
 ```
 
-**Note**: Only one of `keycloak.internal.enabled` or `keycloak.external.enabled` should be set to `true`.
+**Note**: If `keycloak.internal.enabled` is `true`, the `global.oidc.issuer` should be left empty to not override the generated issuer URL.
 
 ### PostgreSQL Settings
 

--- a/charts/opencloud/README.md
+++ b/charts/opencloud/README.md
@@ -275,18 +275,49 @@ This will prepend `my-registry.com/` to all image references in the chart. For e
 
 ### Keycloak Settings
 
+Keycloak configuration follows the standardized internal/external pattern (see issue #64).
+
+#### Internal Keycloak
+
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
-| `keycloak.enabled` | Enable Keycloak | `true` |
-| `keycloak.replicas` | Number of replicas | `1` |
-| `keycloak.adminUser` | Admin user | `admin` |
-| `keycloak.adminPassword` | Admin password | `admin` |
-| `keycloak.resources` | CPU/Memory resource requests/limits | `{}` |
-| `keycloak.realm` | Realm name | `openCloud` |
-| `keycloak.persistence.enabled` | Enable persistence | `true` |
-| `keycloak.persistence.size` | Size of the persistent volume | `1Gi` |
-| `keycloak.persistence.storageClass` | Storage class | `""` |
-| `keycloak.persistence.accessMode` | Access mode | `ReadWriteOnce` |
+| `keycloak.internal.enabled` | Enable internal Keycloak deployment | `true` |
+| `keycloak.internal.image.repository` | Keycloak image repository | `quay.io/keycloak/keycloak` |
+| `keycloak.internal.image.tag` | Keycloak image tag | `26.1.4` |
+| `keycloak.internal.image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `keycloak.internal.replicas` | Number of replicas | `1` |
+| `keycloak.internal.adminUser` | Admin user | `admin` |
+| `keycloak.internal.adminPassword` | Admin password | `admin` |
+| `keycloak.internal.realm` | Realm name | `openCloud` |
+| `keycloak.internal.resources` | CPU/Memory resource requests/limits | `{}` |
+| `keycloak.internal.cors.enabled` | Enable CORS | `true` |
+| `keycloak.internal.cors.allowAllOrigins` | Allow all origins | `true` |
+
+> **Note**: When using internal Keycloak with multiple OpenCloud replicas (`opencloud.replicas > 1`), you must use an external shared database or LDAP. The embedded IDM does not support replication. See [issue #53](https://github.com/opencloud-eu/helm/issues/53) for details.
+
+#### External Keycloak
+
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `keycloak.external.enabled` | Enable external Keycloak | `false` |
+| `keycloak.external.url` | External Keycloak URL (without /realms/...) | `""` |
+| `keycloak.external.realm` | External Keycloak realm | `openCloud` |
+| `keycloak.external.clientId` | External Keycloak client ID | `web` |
+
+#### Example: Using External Keycloak
+
+```yaml
+keycloak:
+  internal:
+    enabled: false
+  external:
+    enabled: true
+    url: "https://keycloak.example.com"
+    realm: "my-realm"
+    clientId: "opencloud-web"
+```
+
+**Note**: Only one of `keycloak.internal.enabled` or `keycloak.external.enabled` should be set to `true`.
 
 ### PostgreSQL Settings
 

--- a/charts/opencloud/templates/gateway/keycloak-https-httproute.yaml
+++ b/charts/opencloud/templates/gateway/keycloak-https-httproute.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.httpRoute.enabled .Values.keycloak.enabled (not .Values.keycloak.external.enabled) }}
+{{- if and .Values.httpRoute.enabled .Values.keycloak.internal.enabled }}
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:

--- a/charts/opencloud/templates/keycloak/deployment.yaml
+++ b/charts/opencloud/templates/keycloak/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.keycloak.enabled .Values.keycloak.internal.enabled }}
+{{- if .Values.keycloak.internal.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -7,7 +7,7 @@ metadata:
     {{- include "opencloud.labels" . | nindent 4 }}
     app.kubernetes.io/component: keycloak
 spec:
-  replicas: {{ .Values.keycloak.replicas }}
+  replicas: {{ .Values.keycloak.internal.replicas }}
   selector:
     matchLabels:
       {{- include "opencloud.selectorLabels" . | nindent 6 }}
@@ -24,8 +24,8 @@ spec:
         fsGroup: 1000
       containers:
         - name: keycloak
-          image: {{ include "opencloud.image" (dict "imageValues" .Values.keycloak.image "global" .Values.global) | quote }}
-          imagePullPolicy: {{ include "opencloud.image.pullPolicy" (dict "pullPolicy" .Values.keycloak.image.pullPolicy "global" .Values.global) }}
+          image: {{ include "opencloud.image" (dict "imageValues" .Values.keycloak.internal.image "global" .Values.global) | quote }}
+          imagePullPolicy: {{ include "opencloud.image.pullPolicy" (dict "pullPolicy" .Values.keycloak.internal.image.pullPolicy "global" .Values.global) }}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -58,29 +58,29 @@ spec:
             - name: KC_FEATURES
               value: impersonation
             - name: KEYCLOAK_ADMIN
-              value: {{ .Values.keycloak.adminUser }}
+              value: {{ .Values.keycloak.internal.adminUser }}
             - name: KEYCLOAK_ADMIN_PASSWORD
-              value: {{ .Values.keycloak.adminPassword }}
-            {{- if .Values.keycloak.cors.enabled }}
+              value: {{ .Values.keycloak.internal.adminPassword }}
+            {{- if .Values.keycloak.internal.cors.enabled }}
             - name: KC_SPI_CORS_ENABLED
               value: "true"
-            {{- if .Values.keycloak.cors.allowAllOrigins }}
+            {{- if .Values.keycloak.internal.cors.allowAllOrigins }}
             - name: KC_SPI_CORS_ORIGINS
               value: "*"
             {{- else }}
             - name: KC_SPI_CORS_ORIGINS
-              value: {{ join "," .Values.keycloak.cors.origins | quote }}
+              value: {{ join "," .Values.keycloak.internal.cors.origins | quote }}
             {{- end }}
             - name: KC_SPI_CORS_METHODS
-              value: {{ .Values.keycloak.cors.methods | quote }}
+              value: {{ .Values.keycloak.internal.cors.methods | quote }}
             - name: KC_SPI_CORS_HEADERS
-              value: {{ .Values.keycloak.cors.headers | quote }}
+              value: {{ .Values.keycloak.internal.cors.headers | quote }}
             - name: KC_SPI_CORS_EXPOSED_HEADERS
-              value: {{ .Values.keycloak.cors.exposedHeaders | quote }}
+              value: {{ .Values.keycloak.internal.cors.exposedHeaders | quote }}
             - name: KC_SPI_CORS_ALLOW_CREDENTIALS
-              value: {{ .Values.keycloak.cors.allowCredentials | quote }}
+              value: {{ .Values.keycloak.internal.cors.allowCredentials | quote }}
             - name: KC_SPI_CORS_MAX_AGE
-              value: {{ .Values.keycloak.cors.maxAge | quote }}
+              value: {{ .Values.keycloak.internal.cors.maxAge | quote }}
             {{- end }}
           ports:
             - name: http
@@ -93,7 +93,7 @@ spec:
               mountPath: /opt/keycloak/data/import-dist/opencloud-realm.json
               subPath: opencloud-realm.json
           resources:
-            {{- toYaml .Values.keycloak.resources | nindent 12 }}
+            {{- toYaml .Values.keycloak.internal.resources | nindent 12 }}
       volumes:
         - name: script
           configMap:

--- a/charts/opencloud/templates/keycloak/ingress.yaml
+++ b/charts/opencloud/templates/keycloak/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.ingress.enabled .Values.keycloak.enabled }}
+{{- if .Values.keycloak.internal.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/charts/opencloud/templates/keycloak/realm-configmap.yaml
+++ b/charts/opencloud/templates/keycloak/realm-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.keycloak.enabled .Values.keycloak.internal.enabled }}
+{{- if .Values.keycloak.internal.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/opencloud/templates/keycloak/script-configmap.yaml
+++ b/charts/opencloud/templates/keycloak/script-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.keycloak.enabled (not .Values.keycloak.external.enabled) }}
+{{- if .Values.keycloak.internal.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/opencloud/templates/keycloak/service.yaml
+++ b/charts/opencloud/templates/keycloak/service.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.keycloak.enabled .Values.keycloak.internal.enabled }}
+{{- if .Values.keycloak.internal.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/opencloud/templates/opencloud/deployment.yaml
+++ b/charts/opencloud/templates/opencloud/deployment.yaml
@@ -200,26 +200,25 @@ spec:
             - name: NOTIFICATIONS_SMTP_ENCRYPTION
               value: "{{ .Values.opencloud.smtp.encryption }}"
             {{- end }}
-            {{- if or .Values.keycloak.internal.enabled .Values.keycloak.external.enabled }}
-            # Keycloak IDP specific configuration
+            {{- if or .Values.keycloak.internal.enabled .Values.global.oidc.issuer }}
+            # IDP specific configuration
             - name: PROXY_AUTOPROVISION_ACCOUNTS
               value: "true"
+            # user properties are edited in the idp, so we hate to make them readonly
+            - name: FRONTEND_READONLY_USER_ATTRIBUTES
+              value: "user.onPremisesSamAccountName,user.displayName,user.mail,user.passwordProfile,user.accountEnabled,user.appRoleAssignments"
             - name: PROXY_ROLE_ASSIGNMENT_DRIVER
               value: "oidc"
             - name: OC_OIDC_ISSUER
-              {{- if .Values.keycloak.external.enabled }}
-              value: "{{ .Values.keycloak.external.url }}/realms/{{ .Values.keycloak.external.realm }}"
+              {{- if .Values.global.oidc.issuer }}
+              value: {{ .Values.global.oidc.issuer | quote }}
               {{- else }}
-              value: "https://{{ include "opencloud.keycloak.domain" . }}/realms/{{ .Values.keycloak.internal.realm }}"
+              value: {{ printf "https://%s/realms/%s" (include "opencloud.keycloak.domain" .) .Values.keycloak.internal.realm | quote }}
               {{- end }}
             - name: PROXY_OIDC_REWRITE_WELLKNOWN
               value: "true"
             - name: WEB_OIDC_CLIENT_ID
-              {{- if .Values.keycloak.external.enabled }}
-              value: "{{ .Values.keycloak.external.clientId }}"
-              {{- else }}
-              value: "web"
-              {{- end }}
+              value: {{ .Values.global.oidc.clientId | quote}}
             - name: PROXY_USER_OIDC_CLAIM
               value: "preferred_username"
             - name: PROXY_USER_CS3_CLAIM
@@ -230,16 +229,15 @@ spec:
               value: "false"
             - name: GRAPH_USERNAME_MATCH
               value: "none"
-            # Additional OIDC settings from docker-compose
             - name: PROXY_ROLE_ASSIGNMENT_OIDC_CLAIM
               value: "roles"
             - name: PROXY_OIDC_ACCESS_TOKEN_VERIFY_METHOD
               value: "jwt"
             - name: WEB_OIDC_METADATA_URL
-              {{- if .Values.keycloak.external.enabled }}
-              value: "{{ .Values.keycloak.external.url }}/realms/{{ .Values.keycloak.external.realm }}/.well-known/openid-configuration"
+              {{- if .Values.global.oidc.issuer }}
+              value: {{ printf "%s/.well-known/openid-configuration" .Values.global.oidc.issuer | quote }}
               {{- else }}
-              value: "https://{{ include "opencloud.keycloak.domain" . }}/realms/{{ .Values.keycloak.internal.realm }}/.well-known/openid-configuration"
+              value: {{ printf "https://%s/realms/%s/.well-known/openid-configuration" (include "opencloud.keycloak.domain" .) .Values.keycloak.internal.realm | quote }}
               {{- end }}
             - name: WEB_OIDC_SCOPE
               value: "openid profile email groups roles"

--- a/charts/opencloud/templates/opencloud/deployment.yaml
+++ b/charts/opencloud/templates/opencloud/deployment.yaml
@@ -200,18 +200,26 @@ spec:
             - name: NOTIFICATIONS_SMTP_ENCRYPTION
               value: "{{ .Values.opencloud.smtp.encryption }}"
             {{- end }}
-            {{- if .Values.keycloak.enabled }}
+            {{- if or .Values.keycloak.internal.enabled .Values.keycloak.external.enabled }}
             # Keycloak IDP specific configuration
             - name: PROXY_AUTOPROVISION_ACCOUNTS
               value: "true"
             - name: PROXY_ROLE_ASSIGNMENT_DRIVER
               value: "oidc"
             - name: OC_OIDC_ISSUER
-              value: "https://{{ include "opencloud.keycloak.domain" . }}/realms/{{ .Values.keycloak.realm }}"
+              {{- if .Values.keycloak.external.enabled }}
+              value: "{{ .Values.keycloak.external.url }}/realms/{{ .Values.keycloak.external.realm }}"
+              {{- else }}
+              value: "https://{{ include "opencloud.keycloak.domain" . }}/realms/{{ .Values.keycloak.internal.realm }}"
+              {{- end }}
             - name: PROXY_OIDC_REWRITE_WELLKNOWN
               value: "true"
             - name: WEB_OIDC_CLIENT_ID
+              {{- if .Values.keycloak.external.enabled }}
+              value: "{{ .Values.keycloak.external.clientId }}"
+              {{- else }}
               value: "web"
+              {{- end }}
             - name: PROXY_USER_OIDC_CLAIM
               value: "preferred_username"
             - name: PROXY_USER_CS3_CLAIM
@@ -228,9 +236,13 @@ spec:
             - name: PROXY_OIDC_ACCESS_TOKEN_VERIFY_METHOD
               value: "jwt"
             - name: WEB_OIDC_METADATA_URL
-              value: "https://{{ include "opencloud.keycloak.domain" . }}/realms/{{ .Values.keycloak.realm }}/.well-known/openid-configuration"
+              {{- if .Values.keycloak.external.enabled }}
+              value: "{{ .Values.keycloak.external.url }}/realms/{{ .Values.keycloak.external.realm }}/.well-known/openid-configuration"
+              {{- else }}
+              value: "https://{{ include "opencloud.keycloak.domain" . }}/realms/{{ .Values.keycloak.internal.realm }}/.well-known/openid-configuration"
+              {{- end }}
             - name: WEB_OIDC_SCOPE
-              value: "openid profile email groups"
+              value: "openid profile email groups roles"
             {{- end }}
             # Admin user password
             - name: IDM_ADMIN_PASSWORD

--- a/charts/opencloud/templates/postgres/deployment.yaml
+++ b/charts/opencloud/templates/postgres/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.postgres.enabled .Values.keycloak.enabled }}
+{{- if and .Values.postgres.enabled .Values.keycloak.internal.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/opencloud/templates/postgres/pvc.yaml
+++ b/charts/opencloud/templates/postgres/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.postgres.enabled .Values.keycloak.enabled .Values.postgres.persistence.enabled }}
+{{- if and .Values.postgres.enabled .Values.keycloak.internal.enabled .Values.postgres.persistence.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/charts/opencloud/templates/postgres/service.yaml
+++ b/charts/opencloud/templates/postgres/service.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.postgres.enabled .Values.keycloak.enabled }}
+{{- if and .Values.postgres.enabled .Values.keycloak.internal.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/opencloud/values.yaml
+++ b/charts/opencloud/values.yaml
@@ -47,11 +47,19 @@ global:
     # secretName for TLS certificate
     secretName: ""
 
+  oidc:
+    # OpenID Connect issuer URL. If set, overrides the default Keycloak internal issuer URL.
+    # This is useful for external OIDC providers or custom Keycloak configurations.
+    # Example: https://keycloak.opencloud.test/realms/openCloud
+    issuer: ""
+    # OIDC client ID for OpenCloud
+    clientId: "web"
+
   # Global storage settings
   storage:
     # Storage class for persistent volumes
     storageClass: ""
-  
+
   # Global image settings
   image:
     # Global registry override - if set, it will override all image registries
@@ -126,17 +134,6 @@ keycloak:
       maxAge: "3600"
     # Resources
     resources: {}
-  
-  # External Keycloak connection
-  external:
-    # Enable external Keycloak
-    enabled: false
-    # External Keycloak URL (without /realms/...)
-    url: ""
-    # External Keycloak realm
-    realm: "openCloud"
-    # External Keycloak client ID
-    clientId: "web"
 
 # PostgreSQL settings for Keycloak
 postgres:

--- a/charts/opencloud/values.yaml
+++ b/charts/opencloud/values.yaml
@@ -82,70 +82,61 @@ busybox:
 # =====================================================================
 
 # Keycloak settings for identity and access management
+# Structure follows issue #64 - standardized internal/external pattern
 keycloak:
-  # Enable Keycloak
-  enabled: true
-  
-  # Keycloak image settings
-  image:
-    # Keycloak image registry
-    registry: quay.io
-    # Keycloak image repository
-    repository: keycloak/keycloak
-    # Keycloak image tag
-    tag: "26.1.4"
-    # Image pull policy
-    pullPolicy: IfNotPresent
-  
-  # Internal test Keycloak instance
+  # Internal Keycloak deployment
   internal:
-    # Enable internal test Keycloak (default: true)
+    # Enable internal Keycloak instance
     enabled: true
+    # Keycloak image settings
+    image:
+      # Keycloak image registry
+      registry: quay.io
+      # Keycloak image repository
+      repository: keycloak/keycloak
+      # Keycloak image tag
+      tag: "26.1.4"
+      # Image pull policy
+      pullPolicy: IfNotPresent
+    # Number of Keycloak replicas
+    replicas: 1
+    # Admin user
+    adminUser: admin
+    # Admin password
+    adminPassword: admin
+    # Keycloak realm
+    realm: "openCloud"
+    # CORS settings for cross-origin requests
+    cors:
+      # Enable CORS
+      enabled: true
+      # Allow all origins
+      allowAllOrigins: true
+      # Allowed origins (used if allowAllOrigins is false)
+      origins: []
+      # Allowed methods
+      methods: "GET,POST,PUT,DELETE,OPTIONS"
+      # Allowed headers
+      headers: "Origin,Accept,Authorization,Content-Type,Cache-Control"
+      # Exposed headers
+      exposedHeaders: "Access-Control-Allow-Origin,Access-Control-Allow-Credentials"
+      # Allow credentials
+      allowCredentials: "true"
+      # Max age in seconds
+      maxAge: "3600"
+    # Resources
+    resources: {}
   
-  # Use external Keycloak
+  # External Keycloak connection
   external:
     # Enable external Keycloak
     enabled: false
-    # External Keycloak URL
+    # External Keycloak URL (without /realms/...)
     url: ""
     # External Keycloak realm
     realm: "openCloud"
     # External Keycloak client ID
     clientId: "web"
-  
-  # Number of Keycloak replicas
-  replicas: 1
-  # Admin user
-  adminUser: admin
-  # Admin password
-  adminPassword: admin
-  
-  # CORS settings for cross-origin requests
-  cors:
-    # Enable CORS
-    enabled: true
-    # Allow all origins
-    allowAllOrigins: true
-    # Allowed origins (used if allowAllOrigins is false)
-    origins: []
-    # Allowed methods
-    methods: "GET,HEAD,OPTIONS,POST,PUT,DELETE"
-    # Allowed headers
-    headers: "Authorization,Content-Type,Accept,Origin,X-Requested-With"
-    # Exposed headers
-    exposedHeaders: "Content-Disposition,Content-Length,Content-Type"
-    # Allow credentials
-    allowCredentials: true
-    # Max age
-    maxAge: 3600
-  
-  # Token settings
-  token:
-    # Access token lifespan in seconds
-    accessTokenLifespan: 3600
-  
-  # Resources allocation
-  resources:
     requests:
       cpu: 100m
       memory: 256Mi

--- a/charts/opencloud/values.yaml
+++ b/charts/opencloud/values.yaml
@@ -137,25 +137,6 @@ keycloak:
     realm: "openCloud"
     # External Keycloak client ID
     clientId: "web"
-    requests:
-      cpu: 100m
-      memory: 256Mi
-    limits:
-      cpu: 1000m
-      memory: 1Gi
-  
-  # Realm name
-  realm: openCloud
-  
-  # Persistence configuration
-  persistence:
-    enabled: true
-    # Size of the persistent volume
-    size: 1Gi
-    # Storage class
-    storageClass: ""
-    # Access mode
-    accessMode: ReadWriteOnce
 
 # PostgreSQL settings for Keycloak
 postgres:


### PR DESCRIPTION
## Summary

This PR implements proper external Keycloak support by restructuring the configuration to follow the standardized internal/external pattern proposed in issue #64.

## Changes

### 1. Restructured Keycloak Configuration
- Changed from flat `keycloak.*` structure to `keycloak.internal.*` and `keycloak.external.*`
- All internal Keycloak settings now under `keycloak.internal`
- External Keycloak settings properly separated under `keycloak.external`

### 2. Fixed External Keycloak Support
- External Keycloak values (`url`, `realm`, `clientId`) are now actually used
- Added proper conditionals to switch between internal and external configurations
- Added 'roles' to `WEB_OIDC_SCOPE` for proper role mapping

### 3. Updated Documentation
- Added comprehensive README section for both internal and external Keycloak
- Included example configuration for external Keycloak
- Added warning about replica limitations with reference to issue #53

## Breaking Changes

⚠️ **This is a breaking change for existing deployments using Keycloak.**

Users need to update their values from:
```yaml
keycloak:
  enabled: true
  replicas: 1
  adminUser: admin
  # ...
```

To:
```yaml
keycloak:
  internal:
    enabled: true
    replicas: 1
    adminUser: admin
    # ...
```

## Tests Performed

### Template Rendering Tests ✅

1. **Helm lint validation**:
   ```bash
   helm lint ./charts/opencloud
   # Result: 1 chart(s) linted, 0 chart(s) failed
   ```

2. **Internal Keycloak configuration**:
   ```bash
   helm template test ./charts/opencloud
   # Verified: OC_OIDC_ISSUER points to internal Keycloak domain
   # Verified: WEB_OIDC_CLIENT_ID uses default "web"
   # Verified: WEB_OIDC_SCOPE includes "roles"
   ```

3. **External Keycloak configuration**:
   ```bash
   helm template test ./charts/opencloud \
     --set keycloak.internal.enabled=false \
     --set keycloak.external.enabled=true \
     --set keycloak.external.url=https://my-keycloak.example.com \
     --set keycloak.external.realm=my-realm \
     --set keycloak.external.clientId=my-client
   # Verified: OC_OIDC_ISSUER = "https://my-keycloak.example.com/realms/my-realm"
   # Verified: WEB_OIDC_CLIENT_ID = "my-client"
   # Verified: WEB_OIDC_METADATA_URL uses external URL
   ```

## Known Limitations

This PR does NOT implement:
- **Confidential client support** (no `clientSecret` field) - OpenCloud currently expects public clients
- **Custom environment variables** - Users still cannot override hardcoded env vars due to duplicate key issues

These would require additional changes to OpenCloud's configuration system and are out of scope for this fix.

## Real-world Testing Needed

We cannot fully test the external Keycloak integration without an actual Keycloak instance. 

@mcfly-0908 - **Your testing would be extremely valuable!** Could you please:
1. Deploy this chart with your external Keycloak configuration
2. Verify that OpenCloud can authenticate against your Keycloak
3. Check if the "no roles in user claims" error is resolved
4. Note: You'll still need to use a public client (not confidential) for now

## Fixes
- Fixes #75 (keycloak.external.realm field is defined but never used)
- Fixes #82 (Different issues with external Keycloak)
- Partially addresses #64 (Standardize internal/external structure across all services)