### PR TITLE
[opencloud] remove the enableBasicAuth variable, as Basic Auth should not be used

### DIFF
--- a/charts/opencloud/README.md
+++ b/charts/opencloud/README.md
@@ -248,7 +248,6 @@ This will prepend `my-registry.com/` to all image references in the chart. For e
 | `opencloud.logColor` | Enable log color | `false` |
 | `opencloud.logPretty` | Enable pretty logging | `false` |
 | `opencloud.insecure` | Insecure mode (for self-signed certificates) | `true` |
-| `opencloud.enableBasicAuth` | Enable basic auth | `false` |
 | `opencloud.adminPassword` | Admin password | `admin` |
 | `opencloud.createDemoUsers` | Create demo users | `false` |
 | `opencloud.resources` | CPU/Memory resource requests/limits | `{}` |

--- a/charts/opencloud/templates/opencloud/deployment.yaml
+++ b/charts/opencloud/templates/opencloud/deployment.yaml
@@ -162,7 +162,7 @@ spec:
               value: {{ tpl (toString .Values.opencloud.insecure) . | quote }}
             # Basic auth (only needed when not using Keycloak)
             - name: PROXY_ENABLE_BASIC_AUTH
-              value: {{ tpl (toString .Values.opencloud.enableBasicAuth) . | quote }}
+              value: false
             # These vars are needed to the csp config file to include the web office apps and the importer
             - name: ONLYOFFICE_DOMAIN
               value: "{{ .Values.global.domain.onlyoffice }}"

--- a/charts/opencloud/values.yaml
+++ b/charts/opencloud/values.yaml
@@ -434,8 +434,6 @@ opencloud:
   logPretty: false
   # Insecure mode (for self-signed certificates)
   insecure: true
-  # Enable basic auth (set to false to use Keycloak only)
-  enableBasicAuth: "{{ not .Values.keycloak.enabled }}"
   # Admin password
   adminPassword: admin
   # Create demo users


### PR DESCRIPTION
According to the discussion in #77, basic authentication should not be supported by the chart.