### PR TITLE
fix - remove basic auth

### DIFF
--- a/charts/opencloud/templates/opencloud/deployment.yaml
+++ b/charts/opencloud/templates/opencloud/deployment.yaml
@@ -162,7 +162,7 @@ spec:
               value: {{ tpl (toString .Values.opencloud.insecure) . | quote }}
             # Basic auth (only needed when not using Keycloak)
             - name: PROXY_ENABLE_BASIC_AUTH
-              value: false
+              value: "false"
             # These vars are needed to the csp config file to include the web office apps and the importer
             - name: ONLYOFFICE_DOMAIN
               value: "{{ .Values.global.domain.onlyoffice }}"


### PR DESCRIPTION
this needs to be a string, 
helm error message:

Deployment in version "v1" cannot be handled as a Deployment: json: cannot unmarshal bool into Go struct field EnvVar.spec.template.spec.containers.env.value of type string