### PR TITLE
fix annotation preset

### DIFF
--- a/charts/opencloud/templates/onlyoffice/ingress.yaml
+++ b/charts/opencloud/templates/onlyoffice/ingress.yaml
@@ -1,27 +1,31 @@
 {{- if and .Values.ingress.enabled .Values.onlyoffice.enabled }}
+# toYaml and manually added key: value pairs cannot be used in the same annotations block,
+# so we use a dict to build all annotations and pass them through toYaml once:
+{{- $annotations := dict }}
+{{- $_ := mergeOverwrite $annotations .Values.ingress.annotations }}
+{{- if eq .Values.ingress.annotationsPreset "traefik" }}
+  # Traefik: attach our pre-defined Middleware
+  {{- $_ := set $annotations "traefik.ingress.kubernetes.io/router.middlewares" (printf "%s-add-x-forwarded-proto-https@kubernetescrd" .Release.Namespace) }}
+{{- else if eq .Values.ingress.annotationsPreset "nginx" }}
+  # NGINX: inject custom header via configuration-snippet
+  {{- $_ := set $annotations "nginx.ingress.kubernetes.io/configuration-snippet" "more_set_headers \"X-Forwarded-Proto: https\";" }}
+{{- else if eq .Values.ingress.annotationsPreset "haproxy" }}
+  # HAProxy: inject custom header via request-set-headers
+  {{- $_ := set $annotations "haproxy.ingress.kubernetes.io/request-set-headers" "X-Forwarded-Proto https" }}
+{{- else if eq .Values.ingress.annotationsPreset "contour" }}
+  # Contour: inject custom header via request-add
+  {{- $_ := set $annotations "projectcontour.io/request-add" "X-Forwarded-Proto: https" }}
+{{- else if eq .Values.ingress.annotationsPreset "istio" }}
+  # Istio: inject custom header via EnvoyFilter
+  {{- $_ := set $annotations "istio.io/request-headers" "X-Forwarded-Proto: https" }}
+{{- end }}
+
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "opencloud.fullname" . }}-onlyoffice
   annotations:
-    {{- toYaml .Values.ingress.annotations | nindent 4 }}
-    {{- if eq .Values.ingress.annotationsPreset "traefik" }}
-    # Traefik: attach our pre-defined Middleware
-    traefik.ingress.kubernetes.io/router.middlewares: {{ .Release.Namespace }}-add-x-forwarded-proto-https@kubernetescrd
-    {{- else if eq .Values.ingress.annotationsPreset "nginx" }}
-    # NGINX: inject custom header via configuration-snippet
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      more_set_headers "X-Forwarded-Proto: https";
-    {{- else if eq .Values.ingress.annotationsPreset "haproxy" }}
-    # HAProxy: inject custom header via request-set-headers
-    haproxy.ingress.kubernetes.io/request-set-headers: "X-Forwarded-Proto https"
-    {{- else if eq .Values.ingress.annotationsPreset "contour" }}
-    # Contour: inject custom header via request-add
-    projectcontour.io/request-add: "X-Forwarded-Proto: https"
-    {{- else if eq .Values.ingress.annotationsPreset "istio" }}
-    # Istio: inject custom header via EnvoyFilter
-    istio.io/request-headers: "X-Forwarded-Proto: https"
-    {{- end }}
+    {{- toYaml $annotations | nindent 4 }}
 spec:
   {{- if .Values.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ingress.ingressClassName | quote }}


### PR DESCRIPTION
I ran into
```
Error: YAML parse error on opencloud/templates/onlyoffice/ingress.yaml: error converting YAML to JSON: yaml: line 7: did not find expected key
```

toYaml and manually added key: value pairs cannot be used in the same annotations block, so we use a dict to build all annotations and pass them through toYaml once