### PR TITLE
support external nats

### DIFF
--- a/charts/opencloud/README.md
+++ b/charts/opencloud/README.md
@@ -288,6 +288,27 @@ This will prepend `my-registry.com/` to all image references in the chart. For e
 | `opencloud.storage.s3.external.bucket` | External S3 bucket | `""` |
 | `opencloud.storage.s3.external.createBucket` | Create bucket if it doesn't exist | `true` |
 
+### NATS Messaging Configuration
+
+| Parameter  | Description | Default |
+| ---------- | ----------- | ------- |
+| `opencloud.nats.external.enabled` | Use an external NATS server (required for high availability) | `false` |
+| `opencloud.nats.external.endpoint` | Endpoint of the external NATS server | `nats.opencloud-nats.svc.cluster.local:4222` |
+| `opencloud.nats.external.cluster` | NATS cluster name | `opencloud-cluster` |
+| `opencloud.nats.external.tls.enabled` | Enable TLS for communication with NATS | `false` |
+| `opencloud.nats.external.tls.certTrusted` | Set to `false` if the external NATS server's certificate is not trusted by default (e.g. self-signed) | `true` |
+| `opencloud.nats.external.tls.insecure` | Disable certificate validation (not recommended for production) | `false` |
+| `opencloud.nats.external.tls.caSecretName` | Name of the Kubernetes Secret containing the CA certificate (only required if `certTrusted` is `false`) | `opencloud-nats-ca` |
+
+> 💡 The secret referenced by `caSecretName` **must contain a key named `ca.crt`** with the root CA certificate used to verify the external NATS server.
+> Example:
+>
+> ```bash
+> kubectl create secret generic opencloud-nats-ca \
+>   --from-file=ca.crt=./path/to/nats-ca.pem \
+>   --namespace your-namespace
+> ```
+
 ### Keycloak Settings
 
 By default the chart deploys an internal keycloak. It can be disabled and replaced with an external IdP.

--- a/charts/opencloud/templates/collaboration/deployment.yaml
+++ b/charts/opencloud/templates/collaboration/deployment.yaml
@@ -68,8 +68,15 @@ spec:
               value: "0.0.0.0:9300"
             - name: MICRO_REGISTRY
               value: "nats-js-kv"
+            {{- if .Values.opencloud.nats.external.enabled }}
+            - name: OC_PERSISTENT_STORE_NODES
+              value: {{ .Values.opencloud.nats.external.endpoint | quote }}
+            - name: MICRO_REGISTRY_ADDRESS
+              value: {{ .Values.opencloud.nats.external.endpoint | quote }}
+            {{- else }}
             - name: MICRO_REGISTRY_ADDRESS
               value: "{{ include "opencloud.opencloud.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:9233"
+            {{- end }}
             {{- if .Values.onlyoffice.enabled }}
             - name: COLLABORATION_WOPI_SRC
               # onlyoffice has to connect to the wopi server from the web

--- a/charts/opencloud/templates/opencloud/deployment.yaml
+++ b/charts/opencloud/templates/opencloud/deployment.yaml
@@ -147,9 +147,13 @@ spec:
             - name: OC_ADD_RUN_SERVICES
               value: {{ join "," . | quote }}
             {{- end }}
-            {{- with .Values.opencloud.excludeServices }}
+            {{- $exclude := .Values.opencloud.excludeServices | default (list) }}
+            {{- if .Values.opencloud.nats.external.enabled }}
+              {{- $exclude = append $exclude "nats" }}
+            {{- end }}
+            {{- if gt (len $exclude) 0 }}
             - name: OC_EXCLUDE_RUN_SERVICES
-              value: {{ join "," . | quote }}
+              value: {{ join "," $exclude | quote }}
             {{- end }}
             # Do not use SSL between proxy and OpenCloud
             - name: PROXY_TLS
@@ -269,13 +273,37 @@ spec:
             # Demo users
             - name: IDM_CREATE_DEMO_USERS
               value: {{ .Values.opencloud.createDemoUsers | quote }}
-            # Make the registry available to the app provider containers
+            {{- if .Values.opencloud.nats.external.enabled }}
+            # Use the external nats as the service registry
+            - name: MICRO_REGISTRY_ADDRESS
+              value: {{ .Values.opencloud.nats.external.endpoint | quote }}
+            # Use the external nats as the cache and persistent store
+            - name: OC_CACHE_STORE_NODES
+              value: {{ .Values.opencloud.nats.external.endpoint | quote }}
+            - name: OC_PERSISTENT_STORE_NODES
+              value: {{ .Values.opencloud.nats.external.endpoint | quote }}
+            # Use the external nats as the messaging system
+            - name: OC_EVENTS_ENDPOINT
+              value: {{ .Values.opencloud.nats.external.endpoint | quote }}
+            - name: OC_EVENTS_CLUSTER
+              value: {{ .Values.opencloud.nats.external.cluster | quote }}
+            - name: OC_EVENTS_ENABLE_TLS
+              value: {{ .Values.opencloud.nats.external.tls.enabled | quote }}
+            - name: OC_EVENTS_TLS_INSECURE
+              value: {{ .Values.opencloud.nats.external.tls.insecure | quote }}
+            {{- if not .Values.opencloud.nats.external.tls.certTrusted }}
+            - name: OC_EVENTS_TLS_ROOT_CA_CERTIFICATE
+              value: /etc/opencloud/nats-ca/ca.crt
+            {{- end }}
+            {{- else }}
             - name: MICRO_REGISTRY_ADDRESS
               value: "127.0.0.1:9233"
+            # Make the registry available to the app provider containers
             - name: NATS_NATS_HOST
               value: "0.0.0.0"
             - name: NATS_NATS_PORT
               value: "9233"
+            {{- end }}
             # CSP configuration
             - name: PROXY_CSP_CONFIG_FILE_LOCATION
               value: "/etc/opencloud/csp.yaml"
@@ -374,6 +402,11 @@ spec:
             - name: config-files
               mountPath: /etc/opencloud/banned-password-list.txt
               subPath: banned-password-list.txt
+            {{- if and (.Values.opencloud.nats.external.enabled) (not .Values.opencloud.nats.external.tls.certTrusted) }}
+            - name: nats-ca
+              mountPath: /etc/opencloud/nats-ca
+              readOnly: true
+            {{- end }}
           resources:
             {{- toYaml .Values.opencloud.resources | nindent 12 }}
       volumes:
@@ -400,6 +433,11 @@ spec:
         - name: proxy-config
           configMap:
             name: {{ include "opencloud.opencloud.fullname" . }}-proxy-config
+        {{ if and (.Values.opencloud.nats.external.enabled) (not .Values.opencloud.nats.external.tls.certTrusted) }}
+        - name: nats-ca
+          secret:
+            secretName: {{ .Values.opencloud.nats.external.tls.caSecretName }}
+        {{ end }}
         {{- if .Values.webExtensions.enabled }}
         - name: extensions
           emptyDir: {}

--- a/charts/opencloud/templates/opencloud/service.yaml
+++ b/charts/opencloud/templates/opencloud/service.yaml
@@ -13,10 +13,12 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    {{- if not .Values.opencloud.nats.external.enabled }}
     - port: 9233
       targetPort: 9233
       protocol: TCP
       name: nats
+    {{- end }}
   selector:
     {{- include "opencloud.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: opencloud

--- a/charts/opencloud/values.yaml
+++ b/charts/opencloud/values.yaml
@@ -477,6 +477,38 @@ opencloud:
     # For very long lists override the file 'files/opencloud/banned-password-list.txt'
     bannedPasswordList: |-
 
+  nats:
+    external:
+      # -- Use an external NATS messaging system instead of the internal one.
+      # Recommended for all production instances.
+      # Needs to be used if HighAvailability is needed.
+      # Needs to be used if OpenCloud shall be used by more than a 2-digit user count.
+      enabled: false
+
+      # -- Endpoint of the messaging system.
+      endpoint: nats.opencloud-nats.svc.cluster.local:4222
+
+      # -- Cluster name to use with the messaging system.
+      cluster: opencloud-cluster
+
+      tls:
+        # -- Enables TLS encrypted communication with the messaging system.
+        # Recommended for production installations.
+        enabled: false
+        
+        # -- Set only to false, if the certificate of your messaging system service is not trusted.
+        # If set to false, you need to put the CA cert of the messaging system server into the secret referenced by "caSecretName"
+        certTrusted: true
+
+        # -- Disables SSL certificate checking for connections to the messaging system server.
+        # -- For self signed certificates, consider to put the CA cert of the messaging system secure server into the secret referenced by "caSecretName"
+        # Not recommended for production installations.
+        insecure: false
+
+        # Use existing CA secret for nats credentials (Note: secretKeyName must be 'ca.crt' with the root CA certificate for NATS)
+        # Only used if certTrusted is false
+        caSecretName : opencloud-nats-ca
+
   # =====================================================================
   # EMAIL (SMTP)
   # =====================================================================

--- a/deployments/nats/README.md
+++ b/deployments/nats/README.md
@@ -1,0 +1,38 @@
+# OpenCloud with NATS deployment example
+
+## Introduction
+
+This example shows how to deploy OpenCloud with NATS as message bus and store.
+It will deploy an OpenCloud instance and NATS, preconfigured to work together.
+
+***Note***: This example is not intended for production use. It is intended to get a working OpenCloud
+with NATS running in Kubernetes as quickly as possible. It is not hardened in any way.
+
+## Getting started
+
+### Prerequisites
+
+This example requires the following things to be installed:
+
+- [Kubernetes](https://kubernetes.io/) cluster, with an ingress controller installed.
+- [Helm](https://helm.sh/) v3
+- [Helmfile](https://github.com/helmfile/helmfile)
+
+### End result
+
+After following the steps in this guide, you should be able to access the following endpoint, you
+may want to add these to your `/etc/hosts` file pointing to your ingress controller IP:
+
+- https://cloud.opencloud.test
+
+Note that if you want to use your own hostname and domain, you will have to change the `global.domain.opencloud` value.
+
+### Deploying
+
+In this directory, run the following commands:
+
+```bash
+$ helmfile sync
+```
+
+This will deploy OpenCloud and NATS.

--- a/deployments/nats/helmfile.yaml
+++ b/deployments/nats/helmfile.yaml
@@ -1,0 +1,120 @@
+repositories:
+  - name: nats
+    url: https://nats-io.github.io/k8s/helm/charts
+
+
+releases:
+  - name: nats
+    namespace: opencloud-nats
+    chart: nats/nats
+    version: 1.3.7
+    labels:
+      ci-lint-skip: true # skip linting this chart in CI
+    values:
+      - config:
+          cluster:
+            enabled: true
+            replicas: 3
+            name: "opencloud-cluster"
+          jetstream:
+            enabled: true
+            memoryStore:
+              enabled: true
+              maxSize: 2Gi
+          merge:
+            00$include: auth.conf
+      - configMap:
+          merge:
+            data:
+              # bcrypted password generated with `nats server passwd`:
+              # nats-sys: O0Z1O5WG2SIisXUToxUPxQUx
+              # opencloud-admin: pwnnH3S42D5dZL90paHEsQop
+              auth.conf: |
+                accounts {
+                  $SYS {
+                    users = [
+                      { user: "nats-sys",
+                        pass: "$2a$11$5BJO2C7WJLjuOm8FBjGjCugs//lL.Sp9gVIBWzU.fITE5MfCbHCMK"
+                      }
+                    ]
+                  }
+                  $OPENCLOUD {
+                    jetstream: enabled
+                    users = [
+                      { user: "opencloud"
+                      },
+                      { user: "opencloud-admin",
+                        pass: "$2a$11$6SAHUpN.m2TXOMSdSZVWsOjQ69VCQOBUmxD8FZ/aJpdvzSEOfRodC"
+                      }
+                    ]
+                  }
+                }
+                no_auth_user: opencloud
+
+  - name: nack-crds
+    namespace: opencloud-nack
+    chart: ./nack
+    labels:
+      ci-lint-skip: true # skip linting this chart in CI
+
+  - name: nack-streams
+    namespace: opencloud-nats
+    chart: ./streams
+    labels:
+      ci-lint-skip: true # skip linting this chart in CI
+    needs:
+      - opencloud-nats/nats
+      - opencloud-nack/nack-crds
+
+  - name: nack
+    namespace: opencloud-nack
+    chart: nats/nack
+    version: 0.29.0
+    labels:
+      ci-lint-skip: true # skip linting this chart in CI
+    values:
+      - namespaced: false
+      - readOnly: false
+    needs:
+      - opencloud-nack/nack-crds
+
+  - name: opencloud
+    chart: ../../charts/opencloud
+    namespace: opencloud
+    values:
+      - global:
+          # TLS settings
+          tls:
+            # Enable TLS
+            enabled: true
+            secretName: opencloud-wildcard-tls
+            # Use self-signed certificates
+            selfSigned: true
+      - opencloud:
+          nats:
+            # Use an external NATS server (required for high availability)
+            external:
+              enabled: true
+              # these are the default values, you can change them if needed
+              #endpoint: nats.opencloud-nats.svc.cluster.local:4222
+              #cluster: opencloud-cluster
+              tls:
+                # we disable TLS verification for this example
+                # for production, you should set this to true and provide a CA certificate
+                enabled: false
+
+      - collabora:
+          # Enable Collabora
+          enabled: true
+          ssl:
+            enabled: false
+            verification: false
+
+      - onlyoffice:
+          enabled: false
+
+      - ingress:
+          # Enable Ingress
+          enabled: true
+          # Ingress class name
+          annotationsPreset: traefik

--- a/deployments/nats/nack/README.md
+++ b/deployments/nats/nack/README.md
@@ -1,0 +1,3 @@
+Contains the CustomResourceDefinitions for NATS Controllers for Kubernetes (NACK)
+
+Taken from https://github.com/nats-io/nack/blob/v0.18.2/deploy/crds.yml

--- a/deployments/nats/nack/crds.yaml
+++ b/deployments/nats/nack/crds.yaml
@@ -1,0 +1,1465 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: streams.jetstream.nats.io
+spec:
+  group: jetstream.nats.io
+  scope: Namespaced
+  names:
+    kind: Stream
+    singular: stream
+    plural: streams
+  versions:
+  - name: v1beta2
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              name:
+                description: A unique name for the Stream.
+                type: string
+                pattern: '^[^.*>]*$'
+                minLength: 1
+              description:
+                description: The description of the stream.
+                type: string
+              subjects:
+                description: A list of subjects to consume, supports wildcards.
+                type: array
+                minLength: 1
+                items:
+                  type: string
+                  minLength: 1
+              retention:
+                description: How messages are retained in the Stream, once this is exceeded old messages are removed.
+                type: string
+                enum:
+                - limits
+                - interest
+                - workqueue
+                default: limits
+              maxConsumers:
+                description: How many Consumers can be defined for a given Stream. -1 for unlimited.
+                type: integer
+                minimum: -1
+                default: -1
+              maxMsgs:
+                description: How many messages may be in a Stream, oldest messages will be removed if the Stream exceeds this size. -1 for unlimited.
+                type: integer
+                minimum: -1
+                default: -1
+              maxBytes:
+                description: How big the Stream may be, when the combined stream size exceeds this old messages are removed. -1 for unlimited.
+                type: integer
+                minimum: -1
+                default: -1
+              discard:
+                description: When a Stream reach it's limits either old messages are deleted or new ones are denied.
+                type: string
+                enum:
+                - old
+                - new
+                default: old
+              discardPerSubject:
+                description: Applies discard policy on a per-subject basis. Requires discard policy 'new' and 'maxMsgs' to be set.
+                type: boolean
+                default: false
+              maxAge:
+                description: Maximum age of any message in the stream, expressed in Go's time.Duration format. Empty for unlimited.
+                type: string
+                default: ''
+              maxMsgsPerSubject:
+                description: The maximum number of messages per subject.
+                type: integer
+                default: 0
+              maxMsgSize:
+                description: The largest message that will be accepted by the Stream. -1 for unlimited.
+                type: integer
+                minimum: -1
+                default: -1
+              storage:
+                description: The storage backend to use for the Stream.
+                type: string
+                enum:
+                - file
+                - memory
+                default: memory
+              replicas:
+                description: How many replicas to keep for each message.
+                type: integer
+                minimum: 1
+                default: 1
+              noAck:
+                description: Disables acknowledging messages that are received by the Stream.
+                type: boolean
+                default: false
+              duplicateWindow:
+                description: The duration window to track duplicate messages for.
+                type: string
+              placement:
+                description: A stream's placement.
+                type: object
+                properties:
+                  cluster:
+                    type: string
+                  tags:
+                    type: array
+                    items:
+                      type: string
+              mirror:
+                description: A stream mirror.
+                type: object
+                properties:
+                  name:
+                    type: string
+                  optStartSeq:
+                    type: integer
+                  optStartTime:
+                    description: Time format must be RFC3339.
+                    type: string
+                  filterSubject:
+                    type: string
+                  externalApiPrefix:
+                    type: string
+                  externalDeliverPrefix:
+                    type: string
+                  subjectTransforms:
+                    description: List of subject transforms for this mirror.
+                    type: array
+                    items:
+                      description: A subject transform pair.
+                      type: object
+                      properties:
+                        source:
+                          description: Source subject.
+                          type: string
+                        dest:
+                          description: Destination subject.
+                          type: string
+              sources:
+                description: A stream's sources.
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    optStartSeq:
+                      type: integer
+                    optStartTime:
+                      description: Time format must be RFC3339.
+                      type: string
+                    filterSubject:
+                      type: string
+                    externalApiPrefix:
+                      type: string
+                    externalDeliverPrefix:
+                      type: string
+                    subjectTransforms:
+                      description: List of subject transforms for this mirror.
+                      type: array
+                      items:
+                        description: A subject transform pair.
+                        type: object
+                        properties:
+                          source:
+                            description: Source subject.
+                            type: string
+                          dest:
+                            description: Destination subject.
+                            type: string
+              sealed:
+                description: Seal an existing stream so no new messages may be added.
+                type: boolean
+                default: false
+              denyDelete:
+                description: When true, restricts the ability to delete messages from a stream via the API. Cannot be changed once set to true.
+                type: boolean
+                default: false
+              denyPurge:
+                description: When true, restricts the ability to purge a stream via the API. Cannot be changed once set to true.
+                type: boolean
+                default: false
+              allowRollup:
+                description: When true, allows the use of the Nats-Rollup header to replace all contents of a stream, or subject in a stream, with a single new message.
+                type: boolean
+                default: false
+              compression:
+                description: Stream specific compression.
+                type: string
+                enum:
+                - s2
+                - none
+                - ''
+                default: ''
+              firstSequence:
+                description: Sequence number from which the Stream will start.
+                type: number
+                default: 0
+              subjectTransform:
+                description: SubjectTransform is for applying a subject transform (to matching messages) when a new message is received.
+                type: object
+                properties:
+                  source:
+                    type: string
+                    description: Source subject.
+                  dest:
+                    type: string
+                    description: Destination subject to transform into.
+              republish:
+                description: Republish configuration of the stream.
+                type: object
+                properties:
+                  destination:
+                    type: string
+                    description: Messages will be additionally published to this subject.
+                  source:
+                    type: string
+                    description: Messages will be published from this subject to the destination subject.
+              allowDirect:
+                description: When true, allow higher performance, direct access to get individual messages.
+                type: boolean
+                default: false
+              mirrorDirect:
+                description: When true, enables direct access to messages from the origin stream.
+                type: boolean
+                default: false
+              consumerLimits:
+                type: object
+                properties:
+                  inactiveThreshold:
+                    description: The duration of inactivity after which a consumer is considered inactive.
+                    type: string
+                  maxAckPending:
+                    description: Maximum number of outstanding unacknowledged messages.
+                    type: integer
+              metadata:
+                description: Additional Stream metadata.
+                type: object
+                additionalProperties:
+                  type: string
+              account:
+                description: Name of the account to which the Stream belongs.
+                type: string
+                pattern: '^[^.*>]*$'
+              creds:
+                description: NATS user credentials for connecting to servers. Please make sure your controller has mounted the creds on this path.
+                type: string
+                default: ''
+              nkey:
+                description: NATS user NKey for connecting to servers.
+                type: string
+                default: ''
+              preventDelete:
+                description: When true, the managed Stream will not be deleted when the resource is deleted.
+                type: boolean
+                default: false
+              preventUpdate:
+                description: When true, the managed Stream will not be updated when the resource is updated.
+                type: boolean
+                default: false
+              servers:
+                description: A list of servers for creating stream.
+                type: array
+                items:
+                  type: string
+                default: []
+              tls:
+                description: A client's TLS certs and keys.
+                type: object
+                properties:
+                  clientCert:
+                    description: A client's cert filepath. Should be mounted.
+                    type: string
+                  clientKey:
+                    description: A client's key filepath. Should be mounted.
+                    type: string
+                  rootCas:
+                    description: A list of filepaths to CAs. Should be mounted.
+                    type: array
+                    items:
+                      type: string
+              tlsFirst:
+                description: When true, the KV Store will initiate TLS before server INFO.
+                type: boolean
+                default: false
+              jsDomain:
+                description: The JetStream domain to use for the stream.
+                type: string
+          status:
+            type: object
+            properties:
+              observedGeneration:
+                type: integer
+              conditions:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    status:
+                      type: string
+                    lastTransitionTime:
+                      type: string
+                    reason:
+                      type: string
+                    message:
+                      type: string
+    additionalPrinterColumns:
+    - name: State
+      type: string
+      description: The current state of the stream.
+      jsonPath: .status.conditions[?(@.type == 'Ready')].reason
+    - name: Stream Name
+      type: string
+      description: The name of the JetStream Stream.
+      jsonPath: .spec.name
+    - name: Subjects
+      type: string
+      description: The subjects this Stream produces.
+      jsonPath: .spec.subjects
+  - name: v1beta1
+    served: false
+    storage: false
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              name:
+                description: A unique name for the Stream.
+                type: string
+                pattern: '^[^.*>]*$'
+                minLength: 1
+              subjects:
+                description: A list of subjects to consume, supports wildcards.
+                type: array
+                minLength: 1
+                items:
+                  type: string
+                  minLength: 1
+              retention:
+                description: How messages are retained in the Stream, once this is exceeded old messages are removed.
+                type: string
+                enum:
+                - limits
+                - interest
+                - workqueue
+                default: limits
+              maxConsumers:
+                description: How many Consumers can be defined for a given Stream. -1 for unlimited.
+                type: integer
+                minimum: -1
+                default: -1
+              maxMsgs:
+                description: How many messages may be in a Stream, oldest messages will be removed if the Stream exceeds this size. -1 for unlimited.
+                type: integer
+                minimum: -1
+                default: -1
+              maxBytes:
+                description: How big the Stream may be, when the combined stream size exceeds this old messages are removed. -1 for unlimited.
+                type: integer
+                minimum: -1
+                default: -1
+              maxAge:
+                description: Maximum age of any message in the stream, expressed in Go's time.Duration format. Empty for unlimited.
+                type: string
+                default: ''
+              maxMsgSize:
+                description: The largest message that will be accepted by the Stream. -1 for unlimited.
+                type: integer
+                minimum: -1
+                default: -1
+              storage:
+                description: The storage backend to use for the Stream.
+                type: string
+                enum:
+                - file
+                - memory
+                default: memory
+              replicas:
+                description: How many replicas to keep for each message.
+                type: integer
+                minimum: 1
+                default: 1
+              noAck:
+                description: Disables acknowledging messages that are received by the Stream.
+                type: boolean
+                default: false
+              discard:
+                description: When a Stream reach it's limits either old messages are deleted or new ones are denied.
+                type: string
+                enum:
+                - old
+                - new
+                default: old
+              duplicateWindow:
+                description: The duration window to track duplicate messages for.
+                type: string
+              description:
+                description: The description of the stream.
+                type: string
+              maxMsgsPerSubject:
+                description: The maximum number of messages per subject.
+                type: integer
+                default: 0
+              mirror:
+                description: A stream mirror.
+                type: object
+                properties:
+                  name:
+                    type: string
+                  optStartSeq:
+                    type: integer
+                  optStartTime:
+                    description: Time format must be RFC3339.
+                    type: string
+                  filterSubject:
+                    type: string
+                  externalApiPrefix:
+                    type: string
+                  externalDeliverPrefix:
+                    type: string
+              placement:
+                description: A stream's placement.
+                type: object
+                properties:
+                  cluster:
+                    type: string
+                  tags:
+                    type: array
+                    items:
+                      type: string
+              sources:
+                description: A stream's sources.
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    optStartSeq:
+                      type: integer
+                    optStartTime:
+                      description: Time format must be RFC3339.
+                      type: string
+                    filterSubject:
+                      type: string
+                    externalApiPrefix:
+                      type: string
+                    externalDeliverPrefix:
+                      type: string
+          status:
+            type: object
+            properties:
+              observedGeneration:
+                type: integer
+              conditions:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    status:
+                      type: string
+                    lastTransitionTime:
+                      type: string
+                    reason:
+                      type: string
+                    message:
+                      type: string
+    additionalPrinterColumns:
+    - name: State
+      type: string
+      description: The current state of the stream.
+      jsonPath: .status.conditions[?(@.type == 'Ready')].reason
+    - name: Stream Name
+      type: string
+      description: The name of the JetStream Stream.
+      jsonPath: .spec.name
+    - name: Subjects
+      type: string
+      description: The subjects this Stream produces.
+      jsonPath: .spec.subjects
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: consumers.jetstream.nats.io
+spec:
+  group: jetstream.nats.io
+  scope: Namespaced
+  names:
+    kind: Consumer
+    singular: consumer
+    plural: consumers
+  versions:
+  - name: v1beta2
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              durableName:
+                description: The name of the Consumer.
+                type: string
+                pattern: '^[^.*>]+$'
+                minLength: 1
+              streamName:
+                description: The name of the Stream to create the Consumer in.
+                type: string
+              deliverPolicy:
+                type: string
+                enum:
+                - all
+                - last
+                - new
+                # Requires optStartSeq
+                - byStartSequence
+                # Requires optStartTime
+                - byStartTime
+                default: all
+              optStartSeq:
+                type: integer
+                minimum: 0
+              optStartTime:
+                description: Time format must be RFC3339.
+                type: string
+              deliverSubject:
+                description: The subject to deliver observed messages, when not set, a pull-based Consumer is created.
+                type: string
+              ackPolicy:
+                description: How messages should be acknowledged.
+                type: string
+                enum:
+                - none
+                - all
+                - explicit
+                default: none
+              ackWait:
+                description: How long to allow messages to remain un-acknowledged before attempting redelivery.
+                type: string
+                default: 1ns
+              maxDeliver:
+                type: integer
+                minimum: -1
+              backoff:
+                description: List of durations representing a retry time scale for NaK'd or retried messages.
+                type: array
+                items:
+                  type: string
+              filterSubject:
+                description: Select only a specific incoming subjects, supports wildcards.
+                type: string
+              filterSubjects:
+                description: List of incoming subjects, supports wildcards. Available since 2.10.
+                type: array
+                items:
+                  type: string
+              replayPolicy:
+                description: How messages are sent.
+                type: string
+                enum:
+                - instant
+                - original
+                default: instant
+              sampleFreq:
+                description: What percentage of acknowledgements should be samples for observability.
+                type: string
+              maxWaiting:
+                description: The number of pulls that can be outstanding on a pull consumer, pulls received after this is reached are ignored.
+                type: integer
+              rateLimitBps:
+                description: Rate at which messages will be delivered to clients, expressed in bit per second.
+                type: integer
+              maxAckPending:
+                description: Maximum pending Acks before consumers are paused.
+                type: integer
+              deliverGroup:
+                description: The name of a queue group.
+                type: string
+              description:
+                description: The description of the consumer.
+                type: string
+              flowControl:
+                description: Enables flow control.
+                type: boolean
+                default: false
+              headersOnly:
+                description: When set, only the headers of messages in the stream are delivered, and not the bodies. Additionally, Nats-Msg-Size header is added to indicate the size of the removed payload.
+                type: boolean
+                default: false
+              heartbeatInterval:
+                description: The interval used to deliver idle heartbeats for push-based consumers, in Go's time.Duration format.
+                type: string
+              maxRequestBatch:
+                description: The largest batch property that may be specified when doing a pull on a Pull Consumer.
+                type: integer
+              maxRequestExpires:
+                description: The maximum expires duration that may be set when doing a pull on a Pull Consumer.
+                type: string
+              maxRequestMaxBytes:
+                description: The maximum max_bytes value that maybe set when dong a pull on a Pull Consumer.
+                type: integer
+              inactiveThreshold:
+                description: The idle time an Ephemeral Consumer allows before it is removed.
+                type: string
+              replicas:
+                description: When set do not inherit the replica count from the stream but specifically set it to this amount.
+                type: integer
+              memStorage:
+                description: Force the consumer state to be kept in memory rather than inherit the setting from the stream.
+                type: boolean
+                default: false
+              metadata:
+                description: Additional Consumer metadata.
+                type: object
+                additionalProperties:
+                  type: string
+              account:
+                description: Name of the account to which the Consumer belongs.
+                type: string
+                pattern: '^[^.*>]*$'
+              creds:
+                description: NATS user credentials for connecting to servers. Please make sure your controller has mounted the creds on its path.
+                type: string
+                default: ''
+              nkey:
+                description: NATS user NKey for connecting to servers.
+                type: string
+                default: ''
+              preventDelete:
+                description: When true, the managed Consumer will not be deleted when the resource is deleted.
+                type: boolean
+                default: false
+              preventUpdate:
+                description: When true, the managed Consumer will not be updated when the resource is updated.
+                type: boolean
+                default: false
+              servers:
+                description: A list of servers for creating consumer.
+                type: array
+                items:
+                  type: string
+                default: []
+              tls:
+                description: A client's TLS certs and keys.
+                type: object
+                properties:
+                  clientCert:
+                    description: A client's cert filepath. Should be mounted.
+                    type: string
+                  clientKey:
+                    description: A client's key filepath. Should be mounted.
+                    type: string
+                  rootCas:
+                    description: A list of filepaths to CAs. Should be mounted.
+                    type: array
+                    items:
+                      type: string
+              tlsFirst:
+                description: When true, the KV Store will initiate TLS before server INFO.
+                type: boolean
+                default: false
+              jsDomain:
+                description: The JetStream domain to use for the consumer.
+                type: string
+          status:
+            type: object
+            properties:
+              observedGeneration:
+                type: integer
+              conditions:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    status:
+                      type: string
+                    lastTransitionTime:
+                      type: string
+                    reason:
+                      type: string
+                    message:
+                      type: string
+    additionalPrinterColumns:
+    - name: State
+      type: string
+      description: The current state of the consumer.
+      jsonPath: .status.conditions[?(@.type == 'Ready')].reason
+    - name: Stream
+      type: string
+      description: The name of the JetStream Stream.
+      jsonPath: .spec.streamName
+    - name: Consumer
+      type: string
+      description: The name of the JetStream Consumer.
+      jsonPath: .spec.durableName
+    - name: Ack Policy
+      type: string
+      description: The ack policy.
+      jsonPath: .spec.ackPolicy
+  - name: v1beta1
+    served: false
+    storage: false
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              streamName:
+                description: The name of the Stream to create the Consumer in.
+                type: string
+              deliverPolicy:
+                type: string
+                enum:
+                - all
+                - last
+                - new
+                # Requires optStartSeq
+                - byStartSequence
+                # Requires optStartTime
+                - byStartTime
+                default: all
+              optStartSeq:
+                type: integer
+                minimum: 0
+              optStartTime:
+                description: Time format must be RFC3339.
+                type: string
+              durableName:
+                description: The name of the Consumer.
+                type: string
+                pattern: '^[^.*>]+$'
+                minLength: 1
+              deliverSubject:
+                description: The subject to deliver observed messages, when not set, a pull-based Consumer is created.
+                type: string
+              ackPolicy:
+                description: How messages should be acknowledged.
+                type: string
+                enum:
+                - none
+                - all
+                - explicit
+                default: none
+              ackWait:
+                description: How long to allow messages to remain un-acknowledged before attempting redelivery.
+                type: string
+                default: 1ns
+              maxDeliver:
+                type: integer
+                minimum: -1
+              filterSubject:
+                description: Select only a specific incoming subjects, supports wildcards.
+                type: string
+              replayPolicy:
+                description: How messages are sent.
+                type: string
+                enum:
+                - instant
+                - original
+                default: instant
+              sampleFreq:
+                description: What percentage of acknowledgements should be samples for observability.
+                type: string
+              rateLimitBps:
+                description: Rate at which messages will be delivered to clients, expressed in bit per second.
+                type: integer
+              maxAckPending:
+                description: Maximum pending Acks before consumers are paused.
+                type: integer
+              deliverGroup:
+                description: The name of a queue group.
+                type: string
+              description:
+                description: The description of the consumer.
+                type: string
+              flowControl:
+                description: Enables flow control.
+                type: boolean
+                default: false
+              heartbeatInterval:
+                description: The interval used to deliver idle heartbeats for push-based consumers, in Go's time.Duration format.
+                type: string
+          status:
+            type: object
+            properties:
+              observedGeneration:
+                type: integer
+              conditions:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    status:
+                      type: string
+                    lastTransitionTime:
+                      type: string
+                    reason:
+                      type: string
+                    message:
+                      type: string
+    additionalPrinterColumns:
+    - name: State
+      type: string
+      description: The current state of the consumer.
+      jsonPath: .status.conditions[?(@.type == 'Ready')].reason
+    - name: Stream
+      type: string
+      description: The name of the JetStream Stream.
+      jsonPath: .spec.streamName
+    - name: Consumer
+      type: string
+      description: The name of the JetStream Consumer.
+      jsonPath: .spec.durableName
+    - name: Ack Policy
+      type: string
+      description: The ack policy.
+      jsonPath: .spec.ackPolicy
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: streamtemplates.jetstream.nats.io
+spec:
+  group: jetstream.nats.io
+  scope: Namespaced
+  names:
+    kind: StreamTemplate
+    singular: streamtemplate
+    plural: streamtemplates
+  versions:
+  - name: v1beta1
+    served: false
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              name:
+                description: A unique name for the Stream Template.
+                type: string
+                pattern: '^[^.*>]*$'
+                minLength: 1
+              maxStreams:
+                description: The maximum number of Streams this Template can create, -1 for unlimited.
+                type: integer
+                minimum: -1
+                default: -1
+              subjects:
+                description: A list of subjects to consume, supports wildcards.
+                type: array
+                minLength: 1
+                items:
+                  type: string
+                  minLength: 1
+              retention:
+                description: How messages are retained in the Stream, once this is exceeded old messages are removed.
+                type: string
+                enum:
+                - limits
+                - interest
+                - workqueue
+                default: limits
+              maxConsumers:
+                description: How many Consumers can be defined for a given Stream. -1 for unlimited.
+                type: integer
+                minimum: -1
+                default: -1
+              maxMsgs:
+                description: How many messages may be in a Stream, oldest messages will be removed if the Stream exceeds this size. -1 for unlimited.
+                type: integer
+                minimum: -1
+                default: -1
+              maxBytes:
+                description: How big the Stream may be, when the combined stream size exceeds this old messages are removed. -1 for unlimited.
+                type: integer
+                minimum: -1
+                default: -1
+              maxAge:
+                description: Maximum age of any message in the stream, expressed in Go's time.Duration format. Empty for unlimited.
+                type: string
+                default: ''
+              maxMsgSize:
+                description: The largest message that will be accepted by the Stream. -1 for unlimited.
+                type: integer
+                minimum: -1
+                default: -1
+              storage:
+                description: The storage backend to use for the Stream.
+                type: string
+                enum:
+                - file
+                - memory
+                default: memory
+              replicas:
+                description: How many replicas to keep for each message.
+                type: integer
+                minimum: 1
+                default: 1
+              noAck:
+                description: Disables acknowledging messages that are received by the Stream.
+                type: boolean
+                default: false
+              discard:
+                description: When a Stream reach it's limits either old messages are deleted or new ones are denied.
+                type: string
+                enum:
+                - old
+                - new
+                default: old
+              duplicateWindow:
+                description: The duration window to track duplicate messages for.
+                type: string
+          status:
+            type: object
+            properties:
+              observedGeneration:
+                type: integer
+              conditions:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    status:
+                      type: string
+                    lastTransitionTime:
+                      type: string
+                    reason:
+                      type: string
+                    message:
+                      type: string
+    additionalPrinterColumns:
+    - name: State
+      type: string
+      description: The current state of the stream.
+      jsonPath: .status.conditions[?(@.type == 'Ready')].reason
+    - name: Stream Template Name
+      type: string
+      description: The name of the JetStream Stream Template.
+      jsonPath: .spec.name
+    - name: Subjects
+      type: string
+      description: The subjects this Stream produces.
+      jsonPath: .spec.subjects
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: accounts.jetstream.nats.io
+spec:
+  group: jetstream.nats.io
+  scope: Namespaced
+  names:
+    kind: Account
+    singular: account
+    plural: accounts
+  versions:
+  - name: v1beta2
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              name:
+                description: A unique name for the Account.
+                type: string
+                pattern: '^[^.*>]*$'
+                minLength: 1
+              creds:
+                description: The creds to be used to connect to the NATS Service.
+                type: object
+                properties:
+                  secret:
+                    type: object
+                    properties:
+                      name:
+                        description: Name of the secret with the creds.
+                        type: string
+                  file:
+                    description: Credentials file, generated with github.com/nats-io/nsc tool.
+                    type: string
+              servers:
+                description: A list of servers to connect.
+                type: array
+                minLength: 1
+                items:
+                  type: string
+                  minLength: 1
+              tls:
+                description: The TLS certs to be used to connect to the NATS Service.
+                type: object
+                properties:
+                  secret:
+                    type: object
+                    properties:
+                      name:
+                        description: Name of the TLS secret with the certs.
+                        type: string
+                  ca:
+                    description: Filename of the Root CA of the TLS cert.
+                    type: string
+                  cert:
+                    description: Filename of the TLS cert.
+                    type: string
+                  key:
+                    description: Filename of the TLS cert key.
+                    type: string
+              token:
+                description: The token to be used to connect to the NATS Service.
+                type: object
+                properties:
+                  secret:
+                    type: object
+                    properties:
+                      name:
+                        description: Name of the secret with the token.
+                        type: string
+                  token:
+                    description: Key in the secret that contains the token.
+                    type: string
+              user:
+                description: The user and password to be used to connect to the NATS Service.
+                type: object
+                properties:
+                  secret:
+                    type: object
+                    properties:
+                      name:
+                        description: Name of the secret with the user and password.
+                        type: string
+                  user:
+                    description: Key in the secret that contains the user.
+                    type: string
+                  password:
+                    description: Key in the secret that contains the password.
+                    type: string
+              tlsFirst:
+                description: When true, the KV Store will initiate TLS before server INFO.
+                type: boolean
+                default: false
+          status:
+            type: object
+            properties:
+              observedGeneration:
+                type: integer
+              conditions:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    status:
+                      type: string
+                    lastTransitionTime:
+                      type: string
+                    reason:
+                      type: string
+                    message:
+                      type: string
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: keyvalues.jetstream.nats.io
+spec:
+  group: jetstream.nats.io
+  scope: Namespaced
+  names:
+    kind: KeyValue
+    singular: keyvalue
+    plural: keyvalues
+    shortNames:
+    - kv
+  versions:
+  - name: v1beta2
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              bucket:
+                description: A unique name for the KV Store.
+                type: string
+              description:
+                description: The description of the KV Store.
+                type: string
+              maxValueSize:
+                description: The maximum size of a value in bytes.
+                type: integer
+              history:
+                description: The number of historical values to keep per key.
+                type: integer
+              ttl:
+                description: The time expiry for keys.
+                type: string
+              maxBytes:
+                description: The maximum size of the KV Store in bytes.
+                type: integer
+              storage:
+                description: The storage backend to use for the KV Store.
+                type: string
+                enum:
+                - file
+                - memory
+              replicas:
+                description: The number of replicas to keep for the KV Store in clustered JetStream.
+                type: integer
+                minimum: 1
+                maximum: 5
+                default: 1
+              placement:
+                description: The KV Store placement via tags or cluster name.
+                type: object
+                properties:
+                  cluster:
+                    type: string
+                  tags:
+                    type: array
+                    items:
+                      type: string
+              republish:
+                description: Republish configuration for the KV Store.
+                type: object
+                properties:
+                  destination:
+                    type: string
+                    description: Messages will be additionally published to this subject after Bucket.
+                  source:
+                    type: string
+                    description: Messages will be published from this subject to the destination subject.
+              mirror:
+                description: A KV Store mirror.
+                type: object
+                properties:
+                  name:
+                    type: string
+                  optStartSeq:
+                    type: integer
+                  optStartTime:
+                    description: Time format must be RFC3339.
+                    type: string
+                  filterSubject:
+                    type: string
+                  externalApiPrefix:
+                    type: string
+                  externalDeliverPrefix:
+                    type: string
+                  subjectTransforms:
+                    description: List of subject transforms for this mirror.
+                    type: array
+                    items:
+                      description: A subject transform pair.
+                      type: object
+                      properties:
+                        source:
+                          description: Source subject.
+                          type: string
+                        dest:
+                          description: Destination subject.
+                          type: string
+              compression:
+                description: KV Store compression.
+                type: boolean
+              sources:
+                description: A KV Store's sources.
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    optStartSeq:
+                      type: integer
+                    optStartTime:
+                      description: Time format must be RFC3339.
+                      type: string
+                    filterSubject:
+                      type: string
+                    externalApiPrefix:
+                      type: string
+                    externalDeliverPrefix:
+                      type: string
+                    subjectTransforms:
+                      description: List of subject transforms for this mirror.
+                      type: array
+                      items:
+                        description: A subject transform pair.
+                        type: object
+                        properties:
+                          source:
+                            description: Source subject.
+                            type: string
+                          dest:
+                            description: Destination subject.
+                            type: string
+              account:
+                description: Name of the account to which the Stream belongs.
+                type: string
+                pattern: '^[^.*>]*$'
+              creds:
+                description: NATS user credentials for connecting to servers. Please make sure your controller has mounted the creds on its path.
+                type: string
+                default: ''
+              nkey:
+                description: NATS user NKey for connecting to servers.
+                type: string
+                default: ''
+              preventDelete:
+                description: When true, the managed KV Store will not be deleted when the resource is deleted.
+                type: boolean
+                default: false
+              preventUpdate:
+                description: When true, the managed KV Store will not be updated when the resource is updated.
+                type: boolean
+                default: false
+              servers:
+                description: A list of servers for creating the KV Store.
+                type: array
+                items:
+                  type: string
+                default: []
+              tls:
+                description: A client's TLS certs and keys.
+                type: object
+                properties:
+                  clientCert:
+                    description: A client's cert filepath. Should be mounted.
+                    type: string
+                  clientKey:
+                    description: A client's key filepath. Should be mounted.
+                    type: string
+                  rootCas:
+                    description: A list of filepaths to CAs. Should be mounted.
+                    type: array
+                    items:
+                      type: string
+              tlsFirst:
+                description: When true, the KV Store will initiate TLS before server INFO.
+                type: boolean
+                default: false
+              jsDomain:
+                description: The JetStream domain to use for the KV store.
+                type: string
+          status:
+            type: object
+            properties:
+              observedGeneration:
+                type: integer
+              conditions:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    status:
+                      type: string
+                    lastTransitionTime:
+                      type: string
+                    reason:
+                      type: string
+                    message:
+                      type: string
+    additionalPrinterColumns:
+    - name: State
+      type: string
+      description: The current state of the KV Store.
+      jsonPath: .status.conditions[?(@.type == 'Ready')].reason
+    - name: KV Store Name
+      type: string
+      description: The name of the KV Store.
+      jsonPath: .spec.bucket
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: objectstores.jetstream.nats.io
+spec:
+  group: jetstream.nats.io
+  scope: Namespaced
+  names:
+    kind: ObjectStore
+    singular: objectstore
+    plural: objectstores
+  versions:
+  - name: v1beta2
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              bucket:
+                description: A unique name for the Object Store.
+                type: string
+              description:
+                description: The description of the Object Store.
+                type: string
+              ttl:
+                description: The time expiry for keys.
+                type: string
+              maxBytes:
+                description: The maximum size of the Store in bytes.
+                type: integer
+              storage:
+                description: The storage backend to use for the Object Store.
+                type: string
+                enum:
+                - file
+                - memory
+              replicas:
+                description: The number of replicas to keep for the Object Store in clustered JetStream.
+                type: integer
+                minimum: 1
+                maximum: 5
+                default: 1
+              placement:
+                description: The Object Store placement via tags or cluster name.
+                type: object
+                properties:
+                  cluster:
+                    type: string
+                  tags:
+                    type: array
+                    items:
+                      type: string
+              compression:
+                description: Object Store compression.
+                type: boolean
+              metadata:
+                description: Additional Object Store metadata.
+                type: object
+                additionalProperties:
+                  type: string
+              account:
+                description: Name of the account to which the Object Store belongs.
+                type: string
+                pattern: '^[^.*>]*$'
+              creds:
+                description: NATS user credentials for connecting to servers. Please make sure your controller has mounted the creds on its path.
+                type: string
+                default: ''
+              nkey:
+                description: NATS user NKey for connecting to servers.
+                type: string
+                default: ''
+              preventDelete:
+                description: When true, the managed Object Store will not be deleted when the resource is deleted.
+                type: boolean
+                default: false
+              preventUpdate:
+                description: When true, the managed Object Store will not be updated when the resource is updated.
+                type: boolean
+                default: false
+              servers:
+                description: A list of servers for creating the Object Store.
+                type: array
+                items:
+                  type: string
+                default: []
+              tls:
+                description: A client's TLS certs and keys.
+                type: object
+                properties:
+                  clientCert:
+                    description: A client's cert filepath. Should be mounted.
+                    type: string
+                  clientKey:
+                    description: A client's key filepath. Should be mounted.
+                    type: string
+                  rootCas:
+                    description: A list of filepaths to CAs. Should be mounted.
+                    type: array
+                    items:
+                      type: string
+              tlsFirst:
+                description: When true, the Object Store will initiate TLS before server INFO.
+                type: boolean
+                default: false
+              jsDomain:
+                description: The JetStream domain to use for the Object Store.
+                type: string
+          status:
+            type: object
+            properties:
+              observedGeneration:
+                type: integer
+              conditions:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    status:
+                      type: string
+                    lastTransitionTime:
+                      type: string
+                    reason:
+                      type: string
+                    message:
+                      type: string
+    additionalPrinterColumns:
+    - name: State
+      type: string
+      description: The current state of the Object Store.
+      jsonPath: .status.conditions[?(@.type == 'Ready')].reason
+    - name: Object Store Name
+      type: string
+      description: The name of the Object Store.
+      jsonPath: .spec.bucket

--- a/deployments/nats/streams/README.md
+++ b/deployments/nats/streams/README.md
@@ -1,0 +1,10 @@
+Preconfigures the nats kv streams used by opencloud:
+
+1. `main-queue`
+General-purpose message bus with unlimited messages, no max size, persistent (file), for long-term async communication.
+
+2. `kv-*` JetStream Key-Value buckets for:
+   * `kv-cache-userinfo` – short-lived in-memory cache
+   * `kv-userlog`, `kv-eventhistory`, `kv-activitylog` – long-lived file-backed data
+   * `kv-service-registry` – volatile service discovery info
+   * `kv-proxy` – for sensitive key material (short-lived, memory storage)

--- a/deployments/nats/streams/opencloud.yaml
+++ b/deployments/nats/streams/opencloud.yaml
@@ -1,0 +1,413 @@
+---
+apiVersion: jetstream.nats.io/v1beta2
+kind: Account
+metadata:
+  name: opencloud-nats
+spec:
+  name: opencloud-nats
+  servers:
+    - nats://nats.opencloud-nats.svc.cluster.local:4222
+
+---
+apiVersion: jetstream.nats.io/v1beta2
+kind: Stream
+metadata:
+  name: main-queue
+spec:
+  account: opencloud-nats
+  allowRollup: false
+  description: OpenCloud message bus
+  discard: old
+  duplicateWindow: "2m0s"
+  maxAge: "168h"
+  maxBytes: -1
+  maxConsumers: -1
+  maxMsgs: -1
+  maxMsgSize: -1
+  maxMsgsPerSubject: 0
+  name: main-queue
+  noAck: false
+  preventDelete: false
+  preventUpdate: false
+  replicas: 3
+  retention: limits
+  storage: file
+  subjects:
+    - main-queue
+
+---
+apiVersion: jetstream.nats.io/v1beta2
+kind: Stream
+metadata:
+  name: kv-cache-userinfo
+spec:
+  account: opencloud-nats
+  allowRollup: true
+  description: OpenCloud proxy userinfo cache
+  denyDelete: true
+  discard: new
+  duplicateWindow: "10s"
+  maxAge: "10s"
+  maxBytes: -1
+  maxConsumers: -1
+  maxMsgs: -1
+  maxMsgSize: -1
+  maxMsgsPerSubject: 1
+  name: KV_cache-userinfo
+  noAck: false
+  allowDirect: false # differs from the OpenCloud product default, but it needs to be like this, reasoning see: https://github.com/owncloud/ocis/issues/8432
+  preventDelete: false
+  preventUpdate: false
+  replicas: 3
+  retention: limits
+  storage: memory
+  subjects:
+    - $KV.cache-userinfo.>
+
+---
+apiVersion: jetstream.nats.io/v1beta2
+kind: Stream
+metadata:
+  name: kv-userlog
+spec:
+  account: opencloud-nats
+  allowRollup: true
+  description: OpenCloud userlog store
+  denyDelete: true
+  discard: new
+  duplicateWindow: "2m0s"
+  maxAge: "336h"
+  maxBytes: -1
+  maxConsumers: -1
+  maxMsgs: -1
+  maxMsgSize: -1
+  maxMsgsPerSubject: 1
+  name: KV_userlog
+  noAck: false
+  allowDirect: false # differs from the OpenCloud product default, but it needs to be like this, reasoning see: https://github.com/owncloud/ocis/issues/8432
+  preventDelete: false
+  preventUpdate: false
+  replicas: 3
+  retention: limits
+  storage: file
+  subjects:
+    - $KV.userlog.>
+
+---
+apiVersion: jetstream.nats.io/v1beta2
+kind: Stream
+metadata:
+  name: kv-activitylog
+spec:
+  account: opencloud-nats
+  allowRollup: true
+  description: OpenCloud activitylog store
+  denyDelete: true
+  discard: new
+  duplicateWindow: "2m0s"
+  maxAge: "336h"
+  maxBytes: -1
+  maxConsumers: -1
+  maxMsgs: -1
+  maxMsgSize: -1
+  maxMsgsPerSubject: 1
+  name: KV_activitylog
+  noAck: false
+  allowDirect: false # differs from the OpenCloud product default, but it needs to be like this, reasoning see: https://github.com/owncloud/ocis/issues/8432
+  preventDelete: false
+  preventUpdate: false
+  replicas: 3
+  retention: limits
+  storage: file
+  subjects:
+    - $KV.activitylog.>
+
+---
+apiVersion: jetstream.nats.io/v1beta2
+kind: Stream
+metadata:
+  name: kv-postprocessing
+spec:
+  account: opencloud-nats
+  allowRollup: true
+  description: OpenCloud postprocessing store
+  denyDelete: true
+  discard: new
+  duplicateWindow: "2m0s"
+  maxAge: "168h"
+  maxBytes: -1
+  maxConsumers: -1
+  maxMsgs: -1
+  maxMsgSize: -1
+  maxMsgsPerSubject: 1
+  name: KV_postprocessing
+  noAck: false
+  allowDirect: false # differs from the OpenCloud product default, but it needs to be like this, reasoning see: https://github.com/owncloud/ocis/issues/8432
+  preventDelete: false
+  preventUpdate: false
+  replicas: 3
+  retention: limits
+  storage: file
+  subjects:
+    - $KV.postprocessing.>
+
+---
+apiVersion: jetstream.nats.io/v1beta2
+kind: Stream
+metadata:
+  name: kv-ids-storage-users
+spec:
+  account: opencloud-nats
+  allowRollup: true
+  description: OpenCloud storageusers id cache
+  denyDelete: true
+  discard: new
+  duplicateWindow: "2m0s"
+  maxAge: "24h"
+  maxBytes: -1
+  maxConsumers: -1
+  maxMsgs: -1
+  maxMsgSize: -1
+  maxMsgsPerSubject: 1
+  name: KV_ids-storage-users
+  noAck: false
+  allowDirect: false # differs from the OpenCloud product default, but it needs to be like this, reasoning see: https://github.com/owncloud/ocis/issues/8432
+  preventDelete: false
+  preventUpdate: false
+  replicas: 3
+  retention: limits
+  storage: memory
+  subjects:
+    - $KV.ids-storage-users.>
+
+---
+apiVersion: jetstream.nats.io/v1beta2
+kind: Stream
+metadata:
+  name: kv-storage-users
+spec:
+  account: opencloud-nats
+  allowRollup: true
+  description: OpenCloud storageusers cache
+  denyDelete: true
+  discard: new
+  duplicateWindow: "2m0s"
+  maxAge: "24h"
+  maxBytes: -1
+  maxConsumers: -1
+  maxMsgs: -1
+  maxMsgSize: -1
+  maxMsgsPerSubject: 1
+  name: KV_storage-users
+  noAck: false
+  allowDirect: false # differs from the OpenCloud product default, but it needs to be like this, reasoning see: https://github.com/owncloud/ocis/issues/8432
+  preventDelete: false
+  preventUpdate: false
+  replicas: 3
+  retention: limits
+  storage: memory
+  subjects:
+    - $KV.storage-users.>
+
+---
+apiVersion: jetstream.nats.io/v1beta2
+kind: Stream
+metadata:
+  name: kv-eventhistory
+spec:
+  account: opencloud-nats
+  allowRollup: true
+  description: OpenCloud userlog store
+  denyDelete: true
+  discard: new
+  duplicateWindow: "2m0s"
+  maxAge: "336h"
+  maxBytes: -1
+  maxConsumers: -1
+  maxMsgs: -1
+  maxMsgSize: -1
+  maxMsgsPerSubject: 1
+  name: KV_eventhistory
+  noAck: false
+  allowDirect: false # differs from the OpenCloud product default, but it needs to be like this, reasoning see: https://github.com/owncloud/ocis/issues/8432
+  preventDelete: false
+  preventUpdate: false
+  replicas: 3
+  retention: limits
+  storage: file
+  subjects:
+    - $KV.eventhistory.>
+
+---
+apiVersion: jetstream.nats.io/v1beta2
+kind: Stream
+metadata:
+  name: kv-service-registry
+spec:
+  account: opencloud-nats
+  allowRollup: true
+  description: OpenCloud service registry
+  denyDelete: true
+  discard: new
+  duplicateWindow: "30s"
+  maxAge: "30s"
+  maxBytes: -1
+  maxConsumers: -1
+  maxMsgs: -1
+  maxMsgSize: -1
+  maxMsgsPerSubject: 1
+  name: KV_service-registry
+  noAck: false
+  allowDirect: false # differs from the OpenCloud product default, but it needs to be like this, reasoning see: https://github.com/owncloud/ocis/issues/8432
+  preventDelete: false
+  preventUpdate: false
+  replicas: 3
+  retention: limits
+  storage: memory
+  subjects:
+    - $KV.service-registry.>
+
+---
+apiVersion: jetstream.nats.io/v1beta2
+kind: Stream
+metadata:
+  name: kv-settings-cache
+spec:
+  account: opencloud-nats
+  allowRollup: true
+  description: OpenCloud settings cache
+  denyDelete: true
+  discard: new
+  duplicateWindow: "2m0s"
+  maxAge: "10m0s"
+  maxBytes: -1
+  maxConsumers: -1
+  maxMsgs: -1
+  maxMsgSize: -1
+  maxMsgsPerSubject: 1
+  name: KV_settings-cache
+  noAck: false
+  allowDirect: false # differs from the OpenCloud product default, but it needs to be like this, reasoning see: https://github.com/owncloud/ocis/issues/8432
+  preventDelete: false
+  preventUpdate: false
+  replicas: 3
+  retention: limits
+  storage: memory
+  subjects:
+    - $KV.settings-cache.>
+
+---
+apiVersion: jetstream.nats.io/v1beta2
+kind: Stream
+metadata:
+  name: kv-storage-system
+spec:
+  account: opencloud-nats
+  allowRollup: true
+  description: OpenCloud storagesystem cache
+  denyDelete: true
+  discard: new
+  duplicateWindow: "2m0s"
+  maxAge: "24h"
+  maxBytes: -1
+  maxConsumers: -1
+  maxMsgs: -1
+  maxMsgSize: -1
+  maxMsgsPerSubject: 1
+  name: KV_storage-system
+  noAck: false
+  allowDirect: false # differs from the OpenCloud product default, but it needs to be like this, reasoning see: https://github.com/owncloud/ocis/issues/8432
+  preventDelete: false
+  preventUpdate: false
+  replicas: 3
+  retention: limits
+  storage: memory
+  subjects:
+    - $KV.storage-system.>
+
+---
+apiVersion: jetstream.nats.io/v1beta2
+kind: Stream
+metadata:
+  name: kv-cache-roles
+spec:
+  account: opencloud-nats
+  allowRollup: true
+  description: OpenCloud graph roles cache
+  denyDelete: true
+  discard: new
+  duplicateWindow: "2m0s"
+  maxAge: "24h"
+  maxBytes: -1
+  maxConsumers: -1
+  maxMsgs: -1
+  maxMsgSize: -1
+  maxMsgsPerSubject: 1
+  name: KV_cache-roles
+  noAck: false
+  allowDirect: false # differs from the OpenCloud product default, but it needs to be like this, reasoning see: https://github.com/owncloud/ocis/issues/8432
+  preventDelete: false
+  preventUpdate: false
+  replicas: 3
+  retention: limits
+  storage: memory
+  subjects:
+    - $KV.cache-roles.>
+
+---
+apiVersion: jetstream.nats.io/v1beta2
+kind: Stream
+metadata:
+  name: kv-proxy
+spec:
+  account: opencloud-nats
+  allowRollup: true
+  description: OpenCloud ocs and proxy signing keys
+  denyDelete: true
+  discard: new
+  duplicateWindow: "2m0s"
+  maxAge: "24h"
+  maxBytes: -1
+  maxConsumers: -1
+  maxMsgs: -1
+  maxMsgSize: -1
+  maxMsgsPerSubject: 1
+  name: KV_proxy
+  noAck: false
+  allowDirect: false # differs from the OpenCloud product default, but it needs to be like this, reasoning see: https://github.com/owncloud/ocis/issues/8432
+  preventDelete: false
+  preventUpdate: false
+  replicas: 3
+  retention: limits
+  storage: memory
+  subjects:
+    - $KV.proxy.>
+
+---
+apiVersion: jetstream.nats.io/v1beta2
+kind: Stream
+metadata:
+  name: kv-opencloud-pkg
+spec:
+  account: opencloud-nats
+  allowRollup: true
+  description: OpenCloud settings roles cache
+  denyDelete: true
+  discard: new
+  duplicateWindow: "2m0s"
+  maxAge: "24h"
+  maxBytes: -1
+  maxConsumers: -1
+  maxMsgs: -1
+  maxMsgSize: -1
+  maxMsgsPerSubject: 1
+  name: KV_opencloud-pkg
+  noAck: false
+  allowDirect: false # differs from the OpenCloud product default, but it needs to be like this, reasoning see: https://github.com/owncloud/ocis/issues/8432
+  preventDelete: false
+  preventUpdate: false
+  replicas: 3
+  retention: limits
+  storage: memory
+  subjects:
+    - $KV.opencloud-pkg.>


### PR DESCRIPTION
This pr add support for an external nats server, a prerequisite for increasing the number of replicas for the opencloud and collaboration services.

I also added a deployment example based on helmfile as it captures well how this is supposed to be configured. We have to preconfigure the nats streams because opencloud does not set them up for production use, yet. See my comment in https://github.com/owncloud/ocis/issues/8432#issuecomment-1959077741 This is still true for opencloud.

- [x] decide where to get the nats certificate from. The old ocis chart used secret refs to generate secrets on helm install. Related: https://github.com/opencloud-eu/helm/pull/63

Let me know what you think