### PR TITLE
add missing edit account url

### DIFF
--- a/charts/opencloud/Chart.yaml
+++ b/charts/opencloud/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
     email: info@opencloud.eu
     url: https://opencloud.eu
 type: application
-version: 0.2.2
+version: 0.2.3
 # renovate: datasource=docker depName=opencloudeu/opencloud-rolling
 appVersion: latest
 kubeVersion: ""

--- a/charts/opencloud/templates/opencloud/deployment.yaml
+++ b/charts/opencloud/templates/opencloud/deployment.yaml
@@ -222,7 +222,7 @@ spec:
             # IDP specific configuration
             - name: PROXY_AUTOPROVISION_ACCOUNTS
               value: "true"
-            # user properties are edited in the idp, so we hate to make them readonly
+            # user properties are edited in the idp, so we have to make them readonly
             - name: FRONTEND_READONLY_USER_ATTRIBUTES
               value: "user.onPremisesSamAccountName,user.displayName,user.mail,user.passwordProfile,user.accountEnabled,user.appRoleAssignments"
             - name: PROXY_ROLE_ASSIGNMENT_DRIVER
@@ -232,6 +232,12 @@ spec:
               value: {{ .Values.global.oidc.issuer | quote }}
               {{- else }}
               value: {{ printf "https://%s/realms/%s" (include "opencloud.keycloak.domain" .) .Values.keycloak.internal.realm | quote }}
+              {{- end }}
+            - name: WEB_OPTION_ACCOUNT_EDIT_LINK_HREF
+              {{- if .Values.global.oidc.accountUrl }}
+              value: {{ .Values.global.oidc.accountUrl | quote }}
+              {{- else }}
+              value: {{ printf "https://%s/realms/%s/account" (include "opencloud.keycloak.domain" .) .Values.keycloak.internal.realm | quote }}
               {{- end }}
             - name: PROXY_OIDC_REWRITE_WELLKNOWN
               value: "true"

--- a/charts/opencloud/values.yaml
+++ b/charts/opencloud/values.yaml
@@ -53,6 +53,10 @@ global:
     issuer: ""
     # OIDC client ID for OpenCloud
     clientId: "web"
+    # OIDC account URL for user account management. If set, overrides the default Keycloak internal account URL.
+    # This is the URL where users can manage their accounts, typically provided by Keycloak.
+    # Example: https://keycloak.opencloud.test/realms/openCloud/account
+    accountUrl: ""
 
   # Global storage settings
   storage:


### PR DESCRIPTION
when users are managed elsewhere we need to configure the edit link