### PR TITLE
fix(keycloak): make ingress creation consistent with other components

### DIFF
--- a/charts/opencloud/templates/keycloak/ingress.yaml
+++ b/charts/opencloud/templates/keycloak/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.keycloak.internal.enabled }}
+{{- if and .Values.ingress.enabled .Values.keycloak.internal.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:


### PR DESCRIPTION
## Summary
- Add check for `.Values.ingress.enabled` to keycloak ingress template
- Now respects global `ingress.enabled` flag like all other components
- Fixes inconsistent behavior where keycloak would create ingress even when globally disabled

## Details
Updated the keycloak ingress template from:
```yaml
{{- if .Values.keycloak.internal.enabled }}
```

to:
```yaml
{{- if and .Values.ingress.enabled .Values.keycloak.internal.enabled }}
```

This brings keycloak in line with all other components (opencloud, collabora, onlyoffice, collaboration) which already check both conditions.

## Testing Done
```bash
# Template rendering tests:
# Test 1: No ingresses created when globally disabled
helm template test ./charts/opencloud --set ingress.enabled=false
# Result: 0 ingress resources created ✓

# Test 2: All ingresses created when enabled
helm template test ./charts/opencloud --set ingress.enabled=true
# Result: All 4 ingresses created (including keycloak) ✓

# Lint check
helm lint ./charts/opencloud
# Result: 1 chart(s) linted, 0 chart(s) failed ✓
```

**Note**: I've tested this with helm template rendering and linting, but have not done a full deployment test. 
Our production setup uses `ingress.enabled: true`, so this change doesn't affect our current deployment.

@Tim-herbie - Could you please test this in your environment where you need to disable ingress globally? Would be great to get your feedback if this solves your use case.

## Test plan for reviewers
- [ ] Deploy with `ingress.enabled: true` - all ingresses should be created
- [ ] Deploy with `ingress.enabled: false` - NO ingresses should be created (including keycloak)
- [ ] Deploy with `ingress.enabled: true` and `keycloak.internal.enabled: false` - keycloak ingress should NOT be created

Fixes #103