### PR TITLE
Update MAINTAINERS.md with team roles and permissions

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,22 +2,16 @@
 
 This file lists the maintainers and reviewers for the OpenCloud Helm Charts repository.
 
-## Maintainers
+## Team Members
 
-Maintainers have the ability to merge PRs, create releases, and guide the overall direction of the project.
-
-- @butonic
-
-## Reviewers
-
-Reviewers have the ability to review PRs and approve them, but do not have merge access.
-
-- @michaelstingl
-- @WrenIX
-- @ferenc-hechler
-- @suse-coder
-- @johanneskastl / @kastl-ars
-- @Tim-herbie
+| Member | Role | Permissions | Known Platforms/Environments |
+|--------|------|-------------|----------------------------|
+| @butonic | Maintainer | Admin | - |
+| @michaelstingl | Co-Maintainer | Write (Push, Merge) | Rackspace Spot, Rancher Desktop (macOS) |
+| @WrenIX | Reviewer | Triage | - |
+| @suse-coder | Reviewer | Triage | Talos + Cilium |
+| @johanneskastl / @kastl-ars | Reviewer | None (pending) | - |
+| @Tim-herbie | Reviewer | None (pending) | External Keycloak, HA deployments |
 
 ## Becoming a Maintainer or Reviewer
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,6 +2,14 @@
 
 This file lists the maintainers and reviewers for the OpenCloud Helm Charts repository.
 
+## Roles
+
+### Maintainers
+Maintainers have the ability to merge PRs, create releases, and guide the overall direction of the project.
+
+### Reviewers
+Reviewers have the ability to review PRs and approve them, but do not have merge access.
+
 ## Team Members
 
 | Member | Role | Permissions | Known Platforms/Environments |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -18,8 +18,8 @@ Reviewers have the ability to review PRs and approve them, but do not have merge
 | @michaelstingl | Co-Maintainer | Write (Push, Merge) | Rackspace Spot, Rancher Desktop (macOS) |
 | @WrenIX | Reviewer | Triage | - |
 | @suse-coder | Reviewer | Triage | Talos + Cilium |
-| @johanneskastl / @kastl-ars | Reviewer | None (pending) | - |
-| @Tim-herbie | Reviewer | None (pending) | External Keycloak, HA deployments |
+| @Tim-herbie | Reviewer | Triage | External Keycloak, HA deployments |
+| @johanneskastl / @kastl-ars | Reviewer | Read (pending Triage) | - |
 
 ## Becoming a Maintainer or Reviewer
 


### PR DESCRIPTION
This PR updates MAINTAINERS.md to better reflect the current team structure and permissions.

## Changes

- Converted to a single table showing all team members with their roles and actual GitHub permissions
- Added platform/environment information to facilitate collaboration
- Removed inactive reviewer (no activity since April)

## Current Permission Status

| Member | GitHub Access |
|--------|--------------|
| @butonic | ✅ Admin |
| @michaelstingl | ✅ Write |
| @WrenIX | ✅ Triage |
| @suse-coder | ✅ Triage |
| @johanneskastl / @kastl-ars | ❌ None |
| @Tim-herbie | ❌ None |

## Action Needed

@johanneskastl @kastl-ars @Tim-herbie - You're listed as reviewers but don't have repository access yet. You should have received collaboration invitations - they may have expired. We'd love to have you actively participating! Please let us know if you need a new invitation.

## Platform Information

The table now includes known platforms/environments for each reviewer to help with:
- Understanding different deployment scenarios
- Connecting people with relevant expertise
- Testing across diverse environments

Feel free to update your platform information if it's missing or has changed!