### PR TITLE
Use correct secret name for SMTP

### DIFF
--- a/charts/opencloud/templates/opencloud/deployment.yaml
+++ b/charts/opencloud/templates/opencloud/deployment.yaml
@@ -199,7 +199,7 @@ spec:
                   name: {{- if .Values.opencloud.smtp.existingSecret }}
                           {{ .Values.opencloud.smtp.existingSecret }}
                         {{- else }}
-                          opencloud-smtp
+                          {{ include "opencloud.opencloud.fullname" . }}-smtp
                         {{- end }}
                   key: smtpUser
             - name: NOTIFICATIONS_SMTP_PASSWORD
@@ -208,7 +208,7 @@ spec:
                   name: {{- if .Values.opencloud.smtp.existingSecret }}
                           {{ .Values.opencloud.smtp.existingSecret }}
                         {{- else }}
-                          opencloud-smtp
+                          {{ include "opencloud.opencloud.fullname" . }}-smtp
                         {{- end }}
                   key: smtpPassword
             - name: NOTIFICATIONS_SMTP_INSECURE


### PR DESCRIPTION
There seemed to be a discrepancy between the name of the generated secret for SMTP credentials when the user doesn't pass an `externalSecret`, and the name of the SMTP secret provided to the deployment spec. This commit fixes the mismatch.