### PR TITLE
Allow use of existing PVCs in values.yaml

### DIFF
--- a/charts/opencloud/templates/collaboration/deployment.yaml
+++ b/charts/opencloud/templates/collaboration/deployment.yaml
@@ -146,9 +146,13 @@ spec:
             {{- toYaml .Values.onlyoffice.collaboration.resources | nindent 12 }}
       volumes:
         - name: etc-opencloud
-          {{- if .Values.opencloud.persistence.enabled }}
+          {{- if .Values.opencloud.persistence.config.enabled }}
           persistentVolumeClaim:
+            {{- if .Values.opencloud.persistence.config.existingClaim }}
+            claimName: {{ .Values.opencloud.persistence.config.existingClaim | quote }}
+            {{- else }}
             claimName: {{ include "opencloud.opencloud.fullname" . }}-config
+            {{- end }}
             readOnly: true
           {{- else }}
           # If persistence is disabled, use an init container to copy the config

--- a/charts/opencloud/templates/minio/deployment.yaml
+++ b/charts/opencloud/templates/minio/deployment.yaml
@@ -107,7 +107,11 @@ spec:
         - name: data
           {{- if .Values.opencloud.storage.s3.internal.persistence.enabled }}
           persistentVolumeClaim:
+            {{- if .Values.opencloud.storage.s3.internal.persistence.existingClaim }}
+            claimName: {{ .Values.opencloud.storage.s3.internal.persistence.existingClaim | quote }}
+            {{- else }}
             claimName: {{ include "opencloud.minio.fullname" . }}-data
+            {{- end }}
           {{- else }}
           emptyDir: {}
           {{- end }}

--- a/charts/opencloud/templates/minio/pvc.yaml
+++ b/charts/opencloud/templates/minio/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.opencloud.storage.s3.internal.persistence.enabled }}
+{{- if and .Values.opencloud.storage.s3.internal.persistence.enabled (not .Values.opencloud.storage.s3.internal.persistence.existingClaim) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/charts/opencloud/templates/onlyoffice/deployment.yaml
+++ b/charts/opencloud/templates/onlyoffice/deployment.yaml
@@ -97,6 +97,10 @@ spec:
         {{- if .Values.onlyoffice.persistence.enabled }}
         - name: onlyoffice-data
           persistentVolumeClaim:
+            {{- if .Values.onlyoffice.persistence.existingClaim }}
+            claimName: {{ .Values.onlyoffice.persistence.existingClaim | quote }}
+            {{- else }}
             claimName: {{ include "opencloud.fullname" . }}-onlyoffice-data
+            {{- end }}
         {{- end }}
 {{- end }}

--- a/charts/opencloud/templates/onlyoffice/pvc.yaml
+++ b/charts/opencloud/templates/onlyoffice/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.onlyoffice.enabled .Values.onlyoffice.persistence.enabled }}
+{{- if and .Values.onlyoffice.enabled (and .Values.onlyoffice.persistence.enabled (not .Values.onlyoffice.persistence.existingClaim)) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/charts/opencloud/templates/opencloud/deployment.yaml
+++ b/charts/opencloud/templates/opencloud/deployment.yaml
@@ -417,16 +417,24 @@ spec:
             {{- toYaml .Values.opencloud.resources | nindent 12 }}
       volumes:
         - name: config
-          {{- if .Values.opencloud.persistence.enabled }}
+          {{- if .Values.opencloud.persistence.config.enabled }}
           persistentVolumeClaim:
+            {{- if .Values.opencloud.persistence.config.existingClaim }}
+            claimName: {{ .Values.opencloud.persistence.config.existingClaim | quote }}
+            {{- else }}
             claimName: {{ include "opencloud.opencloud.fullname" . }}-config
+            {{- end }}
           {{- else }}
           emptyDir: {}
           {{- end }}
         - name: data
-          {{- if .Values.opencloud.persistence.enabled }}
+          {{- if .Values.opencloud.persistence.data.enabled }}
           persistentVolumeClaim:
+            {{- if .Values.opencloud.persistence.data.existingClaim }}
+            claimName: {{ .Values.opencloud.persistence.data.existingClaim | quote }}
+            {{- else }}
             claimName: {{ include "opencloud.opencloud.fullname" . }}-data
+            {{- end }}
           {{- else }}
           emptyDir: {}
           {{- end }}

--- a/charts/opencloud/templates/opencloud/pvc.yaml
+++ b/charts/opencloud/templates/opencloud/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.opencloud.enabled .Values.opencloud.persistence.enabled }}
+{{- if and .Values.opencloud.enabled (and .Values.opencloud.persistence.config.enabled (not .Values.opencloud.persistence.config.existingClaim)) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -10,17 +10,19 @@ metadata:
     app.kubernetes.io/component: opencloud
 spec:
   accessModes:
-    - {{ .Values.opencloud.persistence.accessMode | quote }}
+    - {{ .Values.opencloud.persistence.config.accessMode | quote }}
   resources:
     requests:
-      storage: {{ .Values.opencloud.persistence.configSize | quote }}
-  {{- if .Values.opencloud.persistence.storageClass }}
-  {{- if (eq "-" .Values.opencloud.persistence.storageClass) }}
+      storage: {{ .Values.opencloud.persistence.config.size | quote }}
+  {{- if .Values.opencloud.persistence.config.storageClass }}
+  {{- if (eq "-" .Values.opencloud.persistence.config.storageClass) }}
   storageClassName: ""
   {{- else }}
-  storageClassName: {{ .Values.opencloud.persistence.storageClass | quote }}
+  storageClassName: {{ .Values.opencloud.persistence.config.storageClass | quote }}
   {{- end }}
   {{- end }}
+{{- end }}
+{{- if and .Values.opencloud.enabled (and .Values.opencloud.persistence.data.enabled (not .Values.opencloud.persistence.data.existingClaim)) }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -33,15 +35,16 @@ metadata:
     app.kubernetes.io/component: opencloud
 spec:
   accessModes:
-    - {{ .Values.opencloud.persistence.accessMode | quote }}
+    - {{ .Values.opencloud.persistence.data.accessMode | quote }}
   resources:
     requests:
-      storage: {{ .Values.opencloud.persistence.size | quote }}
-  {{- if .Values.opencloud.persistence.storageClass }}
-  {{- if (eq "-" .Values.opencloud.persistence.storageClass) }}
+      storage: {{ .Values.opencloud.persistence.data.size | quote }}
+  {{- if .Values.opencloud.persistence.data.storageClass }}
+  {{- if (eq "-" .Values.opencloud.persistence.data.storageClass) }}
   storageClassName: ""
   {{- else }}
-  storageClassName: {{ .Values.opencloud.persistence.storageClass | quote }}
+  storageClassName: {{ .Values.opencloud.persistence.data.storageClass | quote }}
   {{- end }}
   {{- end }}
 {{- end }}
+

--- a/charts/opencloud/templates/postgres/deployment.yaml
+++ b/charts/opencloud/templates/postgres/deployment.yaml
@@ -61,7 +61,11 @@ spec:
         - name: data
           {{- if .Values.postgres.persistence.enabled }}
           persistentVolumeClaim:
+            {{- if .Values.postgres.persistence.existingClaim }}
+            claimName: {{ .Values.postgres.persistence.existingClaim | quote }}
+            {{- else }}
             claimName: {{ include "opencloud.postgres.fullname" . }}-data
+            {{- end }}
           {{- else }}
           emptyDir: {}
           {{- end }}

--- a/charts/opencloud/templates/postgres/pvc.yaml
+++ b/charts/opencloud/templates/postgres/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.postgres.enabled .Values.keycloak.internal.enabled .Values.postgres.persistence.enabled }}
+{{- if and .Values.postgres.enabled .Values.keycloak.internal.enabled (and .Values.postgres.persistence.enabled (not .Values.postgres.persistence.existingClaim)) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/charts/opencloud/values.yaml
+++ b/charts/opencloud/values.yaml
@@ -187,6 +187,8 @@ postgres:
   # Persistence configuration
   persistence:
     enabled: true
+    # Name of existing PVC to use (overrides all other persistence values)
+    existingClaim: ""
     # Size of the persistent volume
     size: 1Gi
     # Storage class
@@ -328,6 +330,8 @@ onlyoffice:
   persistence:
     # Enable persistence
     enabled: true
+    # Name of existing PVC to use (overrides all other persistence values)
+    existingClaim: ""
     # Size of the persistent volume
     size: 2Gi
   # Resources allocation
@@ -452,16 +456,28 @@ opencloud:
       memory: 20Gi
   # Persistence configuration
   persistence:
-    # Enable persistence
-    enabled: true
-    # Size of the persistent volume for data
-    size: 30Gi
-    # Size of the persistent volume for config
-    configSize: 5Gi
-    # Storage class
-    storageClass: ""
-    # Access mode (ReadWriteOnce or ReadWriteMany for multiple replicas)
-    accessMode: ReadWriteOnce
+    config:
+      # Enable persistence
+      enabled: true
+      # Name of existing PVC to use (overrides all other persistence values)
+      existingClaim: ""
+      # Size of the persistent volume for config
+      size: 5Gi
+      # Storage class
+      storageClass: ""
+      # Access mode (ReadWriteOnce or ReadWriteMany for multiple replicas)
+      accessMode: ReadWriteOnce
+    data:
+      # Enable persistence
+      enabled: true
+      # Name of existing PVC to use (overrides all other persistence values)
+      existingClaim: ""
+      # Size of the persistent volume for data
+      size: 30Gi
+      # Storage class
+      storageClass: ""
+      # Access mode (ReadWriteOnce or ReadWriteMany for multiple replicas)
+      accessMode: ReadWriteOnce
   # Configuration files
   config:
     theme: "owncloud"
@@ -599,6 +615,8 @@ opencloud:
         # Persistence configuration
         persistence:
           enabled: true
+          # Name of existing PVC to use (overrides all other persistence values)
+          existingClaim: ""
           # Size of the persistent volume
           size: 30Gi
           # Storage class


### PR DESCRIPTION
This PR adds the possibility to specify existing PVC names for all `persistence` blocks, thus letting the user provide their own PVC and PV manifests. This change does not affect existing behaviour as long as `existingClaim` is not provided.

It also splits `opencloud.persistence` into two blocks `config` and `data`, which allows the user to assign openCloud configuration and data directories to separate StorageClasses. This change requires an adjustment in `values.yaml` for existing users.