### PR TITLE
Fix collabora credentials

### DIFF
--- a/charts/opencloud/README.md
+++ b/charts/opencloud/README.md
@@ -396,8 +396,8 @@ This ensures the `X-Forwarded-Proto: https` header is added as required by OnlyO
 | `collabora.image.tag` | Collabora image tag | `24.04.13.2.1` |
 | `collabora.image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `collabora.existingSecret` | Name of the existing secret | `` |
-| `collabora.adminUser` | Admin user | `admin` |
-| `collabora.adminPassword` | Admin password | `admin` |
+| `collabora.admin.username` | Admin user | `admin` |
+| `collabora.admin.password` | Admin password | `admin` |
 | `collabora.ssl.enabled` | Enable SSL | `true` |
 | `collabora.ssl.verification` | SSL verification | `true` |
 | `collabora.resources` | CPU/Memory resource requests/limits | `{}` |

--- a/charts/opencloud/templates/collabora/secrets.yaml
+++ b/charts/opencloud/templates/collabora/secrets.yaml
@@ -5,6 +5,6 @@ metadata:
   name: {{ include "opencloud.fullname" . }}-collabora
 type: Opaque
 stringData:
-  username: {{ .Values.collabora.username }}
-  password: {{ .Values.collabora.password }}
+  username: {{ .Values.collabora.admin.username }}
+  password: {{ .Values.collabora.admin.password }}
 {{- end }}

--- a/charts/opencloud/values.yaml
+++ b/charts/opencloud/values.yaml
@@ -281,7 +281,7 @@ collabora:
 
   admin:
     # ignored if collabora.existingSecret is set
-    user: admin
+    username: admin
 
     # ignored if collabora.existingSecret is set
     password: admin


### PR DESCRIPTION
There is a mismatch between `values.yaml`, the Collabora secrets manifest, and the deployment template as far as Collabora admin username and password are concerned.

This PR fixes the mismatch.