### PR TITLE
feat: simple nginx-no-snippets preset (alternative to #112)

### DIFF
--- a/charts/opencloud/README.md
+++ b/charts/opencloud/README.md
@@ -409,6 +409,38 @@ This ensures the `X-Forwarded-Proto: https` header is added as required by OnlyO
 | `collaboration.enabled` | Enable collaboration service | `true` |
 | `collaboration.resources` | CPU/Memory resource requests/limits | `{}` |
 
+## Ingress Configuration
+
+This chart supports standard Kubernetes Ingress resources for exposing services. For environments requiring specific ingress controller features, annotation presets are available.
+
+### Ingress Settings
+
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `ingress.enabled` | Enable Ingress resources | `false` |
+| `ingress.ingressClassName` | Ingress class name (e.g., nginx, traefik) | `""` |
+| `ingress.annotationsPreset` | Preset for ingress controller annotations | `""` |
+| `ingress.annotations` | Custom annotations for all ingress resources | `{}` |
+
+### Annotation Presets
+
+The `annotationsPreset` parameter helps configure ingress controller-specific features, particularly for OnlyOffice which requires the X-Forwarded-Proto header:
+
+- `nginx` - Uses configuration snippets to inject headers
+- `nginx-no-snippets` - For environments where snippets are forbidden (e.g., Rackspace)
+- `traefik` - Creates required Middleware resources
+- `haproxy` - Uses HAProxy-specific header injection
+- `contour` - Uses Contour request headers
+- `istio` - Uses Istio EnvoyFilter
+
+Example for Rackspace or security-restricted environments:
+```yaml
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  annotationsPreset: nginx-no-snippets
+```
+
 ## Gateway API Configuration
 
 This chart includes HTTPRoute resources that can be used to expose the OpenCloud, Keycloak, and MinIO services externally. The HTTPRoutes are configured to route traffic to the respective services.

--- a/charts/opencloud/templates/onlyoffice/ingress.yaml
+++ b/charts/opencloud/templates/onlyoffice/ingress.yaml
@@ -9,6 +9,10 @@
 {{- else if eq .Values.ingress.annotationsPreset "nginx" }}
   # NGINX: inject custom header via configuration-snippet
   {{- $_ := set $annotations "nginx.ingress.kubernetes.io/configuration-snippet" "more_set_headers \"X-Forwarded-Proto: https\";" }}
+{{- else if eq .Values.ingress.annotationsPreset "nginx-no-snippets" }}
+  # NGINX without snippets: use built-in forwarded headers support
+  {{- $_ := set $annotations "nginx.ingress.kubernetes.io/use-forwarded-headers" "true" }}
+  {{- $_ := set $annotations "nginx.ingress.kubernetes.io/forwarded-for-header" "X-Forwarded-For" }}
 {{- else if eq .Values.ingress.annotationsPreset "haproxy" }}
   # HAProxy: inject custom header via request-set-headers
   {{- $_ := set $annotations "haproxy.ingress.kubernetes.io/request-set-headers" "X-Forwarded-Proto https" }}

--- a/charts/opencloud/values.yaml
+++ b/charts/opencloud/values.yaml
@@ -692,7 +692,11 @@ ingress:
   # Some components (e.g., OnlyOffice) require the X-Forwarded-Proto header to be set.
   #
   # Set 'annotationsPreset' to inject known ingress-controller-specific annotations
-  # for injecting the header. Supported values: nginx, traefik, haproxy, contour, istio
+  # for injecting the header. Supported values: nginx, nginx-no-snippets, traefik, haproxy, contour, istio
+  #
+  # Use 'nginx-no-snippets' for environments where NGINX configuration snippets are forbidden
+  # (e.g., Rackspace, security-restricted clusters). This preset uses built-in NGINX features
+  # instead of custom configuration snippets.
   #
   # If set to "traefik" and OnlyOffice is enabled, the chart will create a Middleware
   # named 'add-x-forwarded-proto-https' for use in both Ingress and Gateway HTTPRoute.


### PR DESCRIPTION
## Summary

This is a **simpler alternative to PR #112** that adds `nginx-no-snippets` support with minimal changes.

## What's different from PR #112?

PR #112:
- Creates a complex helper function (`opencloud.ingress.annotations`)
- Modifies ALL 5 ingress templates
- Adds complexity where it's not needed

This PR:
- Adds just 4 lines to OnlyOffice ingress template
- No helper functions
- No changes to other ingresses
- Minimal, focused solution

## Problem

Some Kubernetes environments (like Rackspace) forbid NGINX configuration snippets. The current `nginx` preset fails with:
```
nginx.ingress.kubernetes.io/configuration-snippet annotation is forbidden
```

## Solution

Add `nginx-no-snippets` preset that uses built-in NGINX features:
```yaml
nginx.ingress.kubernetes.io/use-forwarded-headers: "true"
nginx.ingress.kubernetes.io/forwarded-for-header: "X-Forwarded-For"
```

## Changes

1. **OnlyOffice ingress**: Added 4 lines for the new preset
2. **values.yaml**: Documented the new option
3. **README.md**: Added Ingress Configuration section

## Testing

```bash
helm template test ./charts/opencloud \
  --set ingress.enabled=true \
  --set ingress.annotationsPreset=nginx-no-snippets \
  --set onlyoffice.enabled=true
```

Result: OnlyOffice gets the correct annotations, other ingresses remain unchanged.

## Why this approach?

- **KISS principle**: Keep It Simple
- Only OnlyOffice needs X-Forwarded-Proto header
- No need to touch other components
- Easier to understand and maintain

Fixes #105