### PR TITLE
feat: add helm template validation for office suite exclusivity

### DIFF
--- a/charts/opencloud/templates/_helpers/tpl.yaml
+++ b/charts/opencloud/templates/_helpers/tpl.yaml
@@ -184,3 +184,13 @@ Return the appropriate apiVersion for ingress
 {{- print "networking.k8s.io/v1beta1" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Validate office suite configuration
+Ensures that only one of Collabora or OnlyOffice can be enabled at the same time
+*/}}
+{{- define "opencloud.validateOfficeSuite" -}}
+{{- if and .Values.collabora.enabled .Values.onlyoffice.enabled }}
+  {{- fail "Error: Only one of Collabora or OnlyOffice can be enabled at the same time! Both services use the same WOPI endpoints and cannot coexist. Please set either collabora.enabled=false or onlyoffice.enabled=false" }}
+{{- end }}
+{{- end -}}

--- a/charts/opencloud/templates/opencloud/deployment.yaml
+++ b/charts/opencloud/templates/opencloud/deployment.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.opencloud.enabled }}
+{{- include "opencloud.validateOfficeSuite" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
## Summary

This PR adds Helm template validation to ensure only one office suite (Collabora or OnlyOffice) can be enabled at the same time.

## Problem

Currently, the validation happens at runtime inside the OpenCloud application, leading to:
- Confusing error messages after deployment has already started
- Wasted time and resources
- Poor user experience

## Solution

Added a validation helper that fails fast during `helm template` or `helm install` with a clear error message.

## Implementation

1. Added `opencloud.validateOfficeSuite` helper in `_helpers/tpl.yaml`
2. Called the validation at the beginning of the main deployment template
3. Clear error message explains the conflict and how to fix it

## Testing

```bash
# This now fails immediately with a clear error:
helm template test ./charts/opencloud \
  --set collabora.enabled=true \
  --set onlyoffice.enabled=true

# Error: Only one of Collabora or OnlyOffice can be enabled at the same time! 
# Both services use the same WOPI endpoints and cannot coexist. 
# Please set either collabora.enabled=false or onlyoffice.enabled=false

# These work correctly:
helm template test ./charts/opencloud --set collabora.enabled=true
helm template test ./charts/opencloud --set onlyoffice.enabled=true
```

## Benefits

- ✅ Fail fast - error during template phase, not runtime
- ✅ Clear error message with solution
- ✅ Saves deployment time and resources
- ✅ Better user experience

Fixes #108