### PR TITLE
fix(opencloud): do not create minio pvc if minio disabled

### DIFF
--- a/charts/opencloud/templates/minio/pvc.yaml
+++ b/charts/opencloud/templates/minio/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.opencloud.storage.s3.internal.persistence.enabled (not .Values.opencloud.storage.s3.internal.persistence.existingClaim) }}
+{{- if and .Values.opencloud.storage.s3.internal.enabled (and .Values.opencloud.storage.s3.internal.persistence.enabled (not .Values.opencloud.storage.s3.internal.persistence.existingClaim)) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:


### PR DESCRIPTION
This PR adds a missing condition on minio PVC.

Currently if you use these values, helm will create an unused PVC:
```
            storage:
              s3:
                internal:
                  enabled: false
                external:
                  enabled: true
                  endpoint: https://s3.domain.tld
                  region: default
                  existingSecret: opencloud-s3
                  bucket: opencloud-data
```