### PR TITLE
Set fsGroupChangePolicy: OnRootMismatch to avoid a chown -R

### DIFF
--- a/charts/opencloud/templates/opencloud/deployment.yaml
+++ b/charts/opencloud/templates/opencloud/deployment.yaml
@@ -37,6 +37,7 @@ spec:
     spec:
       securityContext:
         fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
       initContainers:
         - name: init-config
           image: {{ include "opencloud.image" (dict "imageValues" .Values.busybox.image "global" .Values.global) | quote }}


### PR DESCRIPTION
The `securityContext` of the `opencloud` pod sets `fsGroup: 1000` and doesn't specify `fsGroupChangePolicy`, which triggers the default behaviour (i.e. `fsGroupChangePolicy: Always`). This is an issue with the PosixFS backend, because it triggers a very long `chown -R` on the storage volume every time the pod starts.

This PR sets `fsGroupChangePolicy: OnRootMismatch` so that `chown -R` only runs if the files in the root directory of a mounted volume have wrong ownership.