### PR TITLE
feat: add roleAttributePath parameter to OIDC configuration

### DIFF
--- a/charts/opencloud/templates/opencloud/deployment.yaml
+++ b/charts/opencloud/templates/opencloud/deployment.yaml
@@ -255,7 +255,7 @@ spec:
             - name: GRAPH_USERNAME_MATCH
               value: "none"
             - name: PROXY_ROLE_ASSIGNMENT_OIDC_CLAIM
-              value: "roles"
+              value: {{ .Values.global.oidc.roleAttributePath  | default "roles" | quote }}
             - name: PROXY_OIDC_ACCESS_TOKEN_VERIFY_METHOD
               value: "jwt"
             - name: WEB_OIDC_METADATA_URL

--- a/charts/opencloud/values.yaml
+++ b/charts/opencloud/values.yaml
@@ -57,6 +57,10 @@ global:
     # This is the URL where users can manage their accounts, typically provided by Keycloak.
     # Example: https://keycloak.opencloud.test/realms/openCloud/account
     accountUrl: ""
+    # JSON path expression to extract user roles from the OIDC token claims.
+    # This defines where to find the user's roles in the JWT token structure.
+    # Example: If roles are in token.resource_access.web.roles, use "resource_access.web.roles"
+    roleAttributePath: roles
 
   # Global storage settings
   storage:


### PR DESCRIPTION
Add configurable roleAttributePath field to allow extraction of user roles from custom locations within OIDC token claims. This enables support for different OIDC providers that may structure role information differently in their JWT tokens.

- Add roleAttributePath field with documentation
- Default value set to "roles" for backward compatibility
- Includes example usage for nested token structures